### PR TITLE
build(deps): Add bouncycastle jdk18on version

### DIFF
--- a/.github/ISSUE_TEMPLATE/adoption_request.md
+++ b/.github/ISSUE_TEMPLATE/adoption_request.md
@@ -11,14 +11,14 @@ assignees: ''
 
 _Thank you for wanting to contribute to the project! We are very happy to see the functionalities of the EDC being extended. Providing this open-source is a great opportunity for others with similar requirements and to avoid additional work._
 
-_For any details about the guidelines for submitting features, please take a look at the [contribution categories](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/contribution_categories.md)._
+_For any details about the guidelines for submitting features, please take a look at the [contribution categories](https://github.com/eclipse-edc/Connector/blob/main/contribution_categories.md)._
 
 
 ## General information
 
 Please provide some information about your project or code contribution. 
 
-_If you choose to be referenced as a "friend", these will be added to the [known friends list](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/known_friends.md)._
+_If you choose to be referenced as a "friend", these will be added to the [known friends list](https://github.com/eclipse-edc/Connector/blob/main/known_friends.md)._
 _If you choose to add your feature as a core EDC component, links to your current code and correlated issues, discussions, and pull requests are of great importance._
 
 | Title | Description | Contact | Links

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,11 +2,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Open up a blank issue
-    url: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/new
+    url: https://github.com/eclipse-edc/GradlePlugins/issues/new
     about: Don’t see your issue here? Open up a blank one
   - name: Ask a question or get support
-    url: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/categories/q-a
-    about: Ask a question or request support for using the Eclipse Dataspace Connector
+    url: https://github.com/eclipse-edc/Connector/discussions/categories/q-a
+    about: Ask a question or request support for using the Eclipse Dataspace Components
   - name: Take a look at the documentation
-    url: https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/tree/main/docs
+    url: https://github.com/eclipse-edc/docs
     about: Browse the documentation for more information

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,7 @@ assignees: ''
 
 # Feature Request
 
-_If you are missing a feature or have an idea how to improve this project that should first be discussed, please feel free to open up a [discussion](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/discussions/categories/ideas)._
+_If you are missing a feature or have an idea how to improve this project that should first be discussed, please feel free to open up a [discussion](https://github.com/eclipse-edc/Connector/discussions/categories/ideas)._
 
 ## Which Areas Would Be Affected?
 _e.g., DPF, CI, build, transfer, etc._
@@ -19,11 +19,3 @@ _Are there any requirements?_
 
 ## Solution Proposal
 _If possible, provide a (brief!) solution proposal._
-
-## Type of Issue
-_i.e., new feature, improvement, cleanup, etc._
-
-## Checklist
-
-- [ ] assigned appropriate label?
-- [x] **Do NOT select a milestone or an assignee!**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,4 +22,4 @@ Closes # <-- _insert Issue number if one exists_
 - [ ] documented public classes/methods?
 - [ ] added/updated relevant documentation?
 - [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
-- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
+- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,8 @@ assertj = "3.22.0"
 atomikos = "5.0.8"
 awaitility = "4.2.0"
 aws = "2.17.288"
-bouncyCastle = "1.70"
+bouncycastle-jdk18on = "1.72"
+bouncyCastle = "1.70" # this bouncycastle version is deprecated in favor of the jdk18on
 cloudEvents = "2.3.0"
 failsafe = "3.2.4"
 gatling = "3.7.5"
@@ -41,6 +42,9 @@ slf4j = "2.0.0-alpha7"
 # Core EDC dependencies
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
+bouncyCastle-bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle-jdk18on" }
+bouncyCastle-bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle-jdk18on" }
+# these two bouncycastle versions are deprecated in favor of the jdk18on
 bouncyCastle-bcprov = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "bouncyCastle" }
 bouncyCastle-bcpkix = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "bouncyCastle" }
 cloudEvents = { module = "io.cloudevents:cloudevents-http-basic", version.ref = "cloudEvents" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ assertj = "3.22.0"
 atomikos = "5.0.8"
 awaitility = "4.2.0"
 aws = "2.17.288"
-bouncycastle-jdk18on = "1.72"
+bouncyCastle-jdk18on = "1.72"
 bouncyCastle = "1.70" # this bouncycastle version is deprecated in favor of the jdk18on
 cloudEvents = "2.3.0"
 failsafe = "3.2.4"
@@ -42,8 +42,8 @@ slf4j = "2.0.0-alpha7"
 # Core EDC dependencies
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
-bouncyCastle-bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle-jdk18on" }
-bouncyCastle-bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle-jdk18on" }
+bouncyCastle-bcprovJdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle-jdk18on" }
+bouncyCastle-bcpkixJdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncyCastle-jdk18on" }
 # these two bouncycastle versions are deprecated in favor of the jdk18on
 bouncyCastle-bcprov = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "bouncyCastle" }
 bouncyCastle-bcpkix = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "bouncyCastle" }


### PR DESCRIPTION
## What this PR changes/adds

Add version catalog entry for `bouncycastle-jdk18on`

## Why it does that

Version bump

## Further notes

- updated the issue/PR templates as well

## Linked Issue(s)

Closes #64

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
