### PR TITLE
feat: add Maven publication convention

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/EdcBuildPlugin.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/EdcBuildPlugin.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - add maven publication
  *
  */
 
@@ -26,6 +27,7 @@ import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.jacoco;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.jar;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.java;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.mavenPom;
+import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.mavenPublication;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.mavenPublishing;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.nexusPublishing;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.repositories;
@@ -64,6 +66,7 @@ public class EdcBuildPlugin implements Plugin<Project> {
                     defaultDependencies(),
                     checkstyle(),
                     mavenPublishing(),
+                    mavenPublication(),
                     signing(),
                     mavenPom(),
                     jacoco(),

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/Conventions.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/Conventions.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - add maven publication
  *
  */
 
@@ -81,5 +82,9 @@ public class Conventions {
 
     public static EdcConvention openApiMerger() {
         return new OpenApiMergerConvention();
+    }
+    
+    public static EdcConvention mavenPublication() {
+        return new MavenPublicationConvention();
     }
 }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
@@ -31,12 +31,17 @@ public class MavenPublicationConvention implements EdcConvention {
     
     /**
      * Checks whether publishing is explicitly set to false for the target project and, if it is
-     * not, adds a Maven publication to the project, if none exists.
+     * not, adds a Maven publication to the project, if none exists. This only applies for
+     * sub-projects.
      *
      * @param target The project to which the convention applies
      */
     @Override
     public void apply(Project target) {
+        if (target.getRootProject() == target) {
+            return;
+        }
+        
         var buildExt = requireExtension(target, BuildExtension.class);
         var shouldPublish = buildExt.getPublish().getOrElse(DEFAULT_SHOULD_PUBLISH);
         

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
@@ -32,13 +32,14 @@ public class MavenPublicationConvention implements EdcConvention {
     /**
      * Checks whether publishing is explicitly set to false for the target project and, if it is
      * not, adds a Maven publication to the project, if none exists. This only applies for
-     * sub-projects.
+     * sub-projects that contain a build.gradle.kts file.
      *
      * @param target The project to which the convention applies
      */
     @Override
     public void apply(Project target) {
-        if (target.getRootProject() == target) {
+        // do not publish the root project or modules without a build.gradle.kts
+        if (target.getRootProject() == target || !target.file("build.gradle.kts").exists()) {
             return;
         }
         

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2022 Fraunhofer Institute for Software and Systems Engineering
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.edcbuild.conventions;
+
+import org.gradle.api.Project;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPublication;
+
+import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.requireExtension;
+
+/**
+ * Adds a Maven publication to a project if it does not use the application plugin (library module).
+ */
+public class MavenPublicationConvention implements EdcConvention {
+    
+    @Override
+    public void apply(Project target) {
+        var applicationPlugin = target.getPlugins().findPlugin("application");
+        if (applicationPlugin == null) {
+            requireExtension(target, PublishingExtension.class);
+
+            var pe = target.getExtensions().getByType(PublishingExtension.class);
+            pe.publications(publications -> publications.create(target.getName(), MavenPublication.class,
+                    mavenPublication -> mavenPublication.from(target.getComponents().getByName("java"))));
+        }
+    }
+    
+}

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
@@ -29,9 +29,7 @@ public class MavenPublicationConvention implements EdcConvention {
     public void apply(Project target) {
         var applicationPlugin = target.getPlugins().findPlugin("application");
         if (applicationPlugin == null) {
-            requireExtension(target, PublishingExtension.class);
-
-            var pe = target.getExtensions().getByType(PublishingExtension.class);
+            var pe = requireExtension(target, PublishingExtension.class);
             pe.publications(publications -> publications.create(target.getName(), MavenPublication.class,
                     mavenPublication -> mavenPublication.from(target.getComponents().getByName("java"))));
         }


### PR DESCRIPTION
## What this PR changes/adds

Adds a convention for creating Maven publications for all library modules.

## Why it does that

So that the `publishing` does not have to be explicitely configured for every module.

## Linked Issue(s)

Closes #58 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
