### PR TITLE
chore: add publish flag

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/BuildExtension.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/BuildExtension.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer Institute for Software and Systems Engineering - add publish property
  *
  */
 
@@ -59,4 +60,6 @@ public abstract class BuildExtension {
     public SwaggerGeneratorExtension getSwagger() {
         return swagger;
     }
+    
+    public abstract Property<Boolean> getPublish();
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds a `publish` flag to the plugin. The flag doesn't have any effect yet.

## Why it does that

Once #67 is merged, publications will be added automatically and the `publish` flag can be used to disable this for a module. To ease the process of merging the changes in all repositories, the `publish` flag is added beforehand.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
