### PR TITLE
chore: upgrade to Gradle 8.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugins/autodoc/autodoc-plugin/build.gradle.kts
+++ b/plugins/autodoc/autodoc-plugin/build.gradle.kts
@@ -19,6 +19,9 @@ val assertj: String by project
 val groupId: String by project
 
 gradlePlugin {
+    website.set("https://projects.eclipse.org/proposals/eclipse-dataspace-connector")
+    vcsUrl.set("https://github.com/eclipse-dataspaceconnector/GradlePlugins.git")
+
     // Define the plugin
     plugins {
         create("autodoc") {
@@ -27,13 +30,7 @@ gradlePlugin {
                 "Plugin to generate a documentation manifest for the EDC Metamodel, i.e. extensions, SPIs, etc."
             id = "${groupId}.autodoc"
             implementationClass = "org.eclipse.edc.plugins.autodoc.AutodocPlugin"
+            tags.set(listOf("build", "documentation", "generated", "autodoc"))
         }
     }
-}
-
-pluginBundle {
-    website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
-    vcsUrl = "https://github.com/eclipse-dataspaceconnector/GradlePlugins.git"
-    version = version
-    tags = listOf("build", "documentation", "generated", "autodoc")
 }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocDependencyInjector.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocDependencyInjector.java
@@ -47,7 +47,16 @@ class AutodocDependencyInjector implements DependencyResolutionListener {
 
     @Override
     public void beforeResolve(ResolvableDependencies dependencies) {
-        var artifact = dependencyName + versionSupplier.get();
+        var version = versionSupplier.get();
+
+        var artifact = dependencyName;
+        if (version != null) {
+            artifact += ":" + version;
+        } else {
+            artifact += ":+";
+            project.getLogger().warn("No explicit configuration value for the annotationProcessor version was found. Please supply a configuration for the Autodoc Plugin's annotationProcessor.");
+        }
+
         if (addDependency(project, artifact)) {
             var task = project.getTasks().findByName("compileJava");
             if ((task instanceof JavaCompile)) {

--- a/plugins/edc-build/build.gradle.kts
+++ b/plugins/edc-build/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
 }
 
 gradlePlugin {
+    website.set("https://projects.eclipse.org/proposals/eclipse-dataspace-connector")
+    vcsUrl.set("https://github.com/eclipse-dataspaceconnector/GradlePlugins.git")
     // Define the plugins
     plugins {
         create("edc-build-base") {
@@ -35,6 +37,7 @@ gradlePlugin {
                 "Meta-plugin that provides the capabilities of the EDC build"
             id = "${groupId}.edc-build-base"
             implementationClass = "org.eclipse.edc.plugins.edcbuild.EdcBuildBasePlugin"
+            tags.set(listOf("build", "verification", "test"))
         }
         create("edc-build") {
             displayName = "edc-build"
@@ -42,13 +45,7 @@ gradlePlugin {
                 "Plugin that applies the base capabilities and provides default configuration for the EDC build"
             id = "${groupId}.edc-build"
             implementationClass = "org.eclipse.edc.plugins.edcbuild.EdcBuildPlugin"
+            tags.set(listOf("build", "verification", "test"))
         }
     }
-}
-
-pluginBundle {
-    website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
-    vcsUrl = "https://github.com/eclipse-dataspaceconnector/GradlePlugins.git"
-    version = version
-    tags = listOf("build", "verification", "test")
 }

--- a/plugins/module-names/build.gradle.kts
+++ b/plugins/module-names/build.gradle.kts
@@ -8,6 +8,8 @@ val assertj: String by project
 val groupId: String by project
 
 gradlePlugin {
+    website.set("https://projects.eclipse.org/proposals/eclipse-dataspace-connector")
+    vcsUrl.set("https://github.com/eclipse-dataspaceconnector/GradlePlugins.git")
     // Define the plugin
     plugins {
         create("module-names") {
@@ -16,13 +18,8 @@ gradlePlugin {
                 "Plugin to verify that a project has no duplicate submodules (by name)"
             id = "${groupId}.module-names"
             implementationClass = "org.eclipse.edc.plugins.modulenames.ModuleNamesPlugin"
+            tags.set(listOf("build", "verification"))
+            version = version
         }
     }
-}
-
-pluginBundle {
-    website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
-    vcsUrl = "https://github.com/eclipse-dataspaceconnector/GradlePlugins.git"
-    version = version
-    tags = listOf("build", "verification")
 }

--- a/plugins/openapi-merger/build.gradle.kts
+++ b/plugins/openapi-merger/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
 }
 
 gradlePlugin {
+    website.set("https://projects.eclipse.org/proposals/eclipse-dataspace-connector")
+    vcsUrl.set("https://github.com/eclipse-dataspaceconnector/GradlePlugins.git")
     // Define the plugin
     plugins {
         create("openapi-merger") {
@@ -23,13 +25,7 @@ gradlePlugin {
                 "Plugin to several OpenAPI spec files into one"
             id = "${groupId}.openapi-merger"
             implementationClass = "org.eclipse.edc.plugins.openapimerger.OpenApiMergerPlugin"
+            tags.set(listOf("build", "openapi", "merge", "documentation"))
         }
     }
-}
-
-pluginBundle {
-    website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
-    vcsUrl = "https://github.com/eclipse-dataspaceconnector/GradlePlugins.git"
-    version = version
-    tags = listOf("build", "openapi", "merge", "documentation")
 }

--- a/plugins/test-summary/build.gradle.kts
+++ b/plugins/test-summary/build.gradle.kts
@@ -8,6 +8,9 @@ val assertj: String by project
 val groupId: String by project
 
 gradlePlugin {
+    website.set("https://projects.eclipse.org/proposals/eclipse-dataspace-connector")
+    vcsUrl.set("https://github.com/eclipse-dataspaceconnector/GradlePlugins.git")
+
     // Define the plugin
     plugins {
         create("test-summary") {
@@ -16,13 +19,7 @@ gradlePlugin {
                 "Plugin to verify that a project has no duplicate submodules (by name)"
             id = "${groupId}.test-summary"
             implementationClass = "org.eclipse.edc.plugins.testsummary.TestSummaryPlugin"
+            tags.set(listOf("build", "verification", "test"))
         }
     }
-}
-
-pluginBundle {
-    website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
-    vcsUrl = "https://github.com/eclipse-dataspaceconnector/GradlePlugins.git"
-    version = version
-    tags = listOf("build", "verification", "test")
 }


### PR DESCRIPTION
## What this PR changes/adds

Upgrades to Gradle 8.0

## Why it does that

Keep up-to-date with Gradle developments, avoid potentially insurmountable technical debt down the line.

## Further notes

- Configuration blocks for the plugins had to adapted.
- resolving the module's own version for the `annotationProcessor` dependency (`autodoc`) is not allowed anymore, thus in case no explicit `processorVersion` is set in client projects, the injector simply sets `"<GROUP>:<ARTIFACT>:+"`, which is **NOT RECOMMENDED**. Thus, a warning is also logged. 
- The alternative would be to use an empty version string `"<GROUP>:<ARTIFACT>"`, causing the build to fail, or just throw a `GradleException`

## Linked Issue(s)

.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
