### PR TITLE
fix: let users set the group id

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
@@ -25,10 +25,12 @@ import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.r
  * Adds a Maven publication to a project.
  */
 public class MavenPublicationConvention implements EdcConvention {
-    
-    /** Default setting for publication of a project. */
+
+    /**
+     * Default setting for publication of a project.
+     */
     private static final boolean DEFAULT_SHOULD_PUBLISH = true;
-    
+
     /**
      * Checks whether publishing is explicitly set to false for the target project and, if it is
      * not, adds a Maven publication to the project, if none exists. This only applies for
@@ -42,18 +44,21 @@ public class MavenPublicationConvention implements EdcConvention {
         if (target.getRootProject() == target || !target.file("build.gradle.kts").exists()) {
             return;
         }
-        
+
         var buildExt = requireExtension(target, BuildExtension.class);
         var shouldPublish = buildExt.getPublish().getOrElse(DEFAULT_SHOULD_PUBLISH);
-        
+
         if (shouldPublish) {
             var pe = requireExtension(target, PublishingExtension.class);
-            
+
             if (pe.getPublications().findByName(target.getName()) == null) {
                 pe.publications(publications -> publications.create(target.getName(), MavenPublication.class,
-                        mavenPublication -> mavenPublication.from(target.getComponents().getByName("java"))));
+                        mavenPublication -> {
+                            mavenPublication.from(target.getComponents().getByName("java"));
+                            mavenPublication.setGroupId(buildExt.getPom().getGroupId());
+                        }));
             }
         }
     }
-    
+
 }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/MavenPomExtension.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/MavenPomExtension.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.plugins.edcbuild.extensions;
 import org.gradle.api.provider.Property;
 
 public abstract class MavenPomExtension {
+    private String groupId = "org.eclipse.edc";
+
     public abstract Property<String> getProjectName();
 
     public abstract Property<String> getDescription();
@@ -36,5 +38,13 @@ public abstract class MavenPomExtension {
     public abstract Property<String> getScmConnection();
 
     public abstract Property<String> getScmUrl();
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Allows downstream projects to explicitly set the GroupID on the pom for publishing.

## Why it does that

fixes a bug with publications

## Further notes

the default is still `org.eclipse.edc`

## Linked Issue(s)

.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
