### PR TITLE
feat: allow adding a repository to publish via CLI parameters

### DIFF
--- a/plugins/edc-build/README.md
+++ b/plugins/edc-build/README.md
@@ -1,7 +1,22 @@
 This module contains a Gradle Plugin, that acts as a "meta-plugin" of sorts, because it performs the following tasks:
 
 - pulls in some other plugins EDC plugins
-- pulls in some general plugins, e.g. `maven-publish`
+- pulls in some general plugins, e.g. `maven-publish`. There is a way to specify the Maven repository through a couple
+  of System properties:
+    - `edc.publish.url`: the URL of the Maven repo
+    - `edc.publish.repoName`: the name of the repo. Relevant for the `publish...` command
+    - `edc.publish.username`: the repo username
+    - `edc.publish.password`: the repo password
+      Thus, the target repo for publication could be specified as follows:
+    ```bash
+    ./gradlew  -Dedc.publish.repoName=foobar \                                                                                                                                                                                                        
+     -Dedc.publish.url="http://localhost:8081/repository/maven-snapshots/" \
+     -Dedc.publish.user=admin \
+     -Dedc.publish.password=admin \
+     publishAllPublicationsToFoobar
+    ```
+  Note that the `edc.publish.repoName=foobar` is important, because it will define actual
+  command `publishAllPublicationsToFoobar`
 - performs general configuration, e.g. adding standard dependencies to all projects
 - applies the `groupId`
 - applies all values for the signing config, e.g. developer name, etc.

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublishingConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublishingConvention.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.plugins.edcbuild.conventions;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.publish.PublishingExtension;
 
 import java.util.Optional;
@@ -37,10 +36,8 @@ class MavenPublishingConvention implements EdcConvention {
         }
         var pubExt = requireExtension(target, PublishingExtension.class);
 
-        if (pubExt.getRepositories().stream().noneMatch(repo -> repo.getName().equals(Repositories.REPO_NAME_SONATYPE) && repo instanceof MavenArtifactRepository)) {
-            Optional.ofNullable(getRepoOverride())
-                    .ifPresent(pubExt::repositories);
-        }
+        Optional.ofNullable(getRepoOverride())
+                .ifPresent(pubExt::repositories);
     }
 
     private Action<? super RepositoryHandler> getRepoOverride() {

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublishingConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublishingConvention.java
@@ -14,21 +14,21 @@
 
 package org.eclipse.edc.plugins.edcbuild.conventions;
 
+import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.publish.PublishingExtension;
 
+import java.util.Optional;
+
 import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.requireExtension;
-import static org.eclipse.edc.plugins.edcbuild.conventions.Repositories.releaseRepo;
-import static org.eclipse.edc.plugins.edcbuild.conventions.Repositories.snapshotRepo;
 
 /**
  * Configures the Maven repos for publishing depending on the project's version
  */
 class MavenPublishingConvention implements EdcConvention {
 
-
-    private static final String SNAPSHOT_SUFFIX = "-SNAPSHOT";
 
     @Override
     public void apply(Project target) {
@@ -38,13 +38,29 @@ class MavenPublishingConvention implements EdcConvention {
         var pubExt = requireExtension(target, PublishingExtension.class);
 
         if (pubExt.getRepositories().stream().noneMatch(repo -> repo.getName().equals(Repositories.REPO_NAME_SONATYPE) && repo instanceof MavenArtifactRepository)) {
-
-            if (target.getVersion().toString().endsWith(SNAPSHOT_SUFFIX)) {
-                pubExt.repositories(snapshotRepo());
-            } else {
-                pubExt.repositories(releaseRepo());
-            }
+            Optional.ofNullable(getRepoOverride())
+                    .ifPresent(pubExt::repositories);
         }
+    }
+
+    private Action<? super RepositoryHandler> getRepoOverride() {
+        var repoUrl = System.getProperty("edc.publish.url");
+        var repoName = System.getProperty("edc.publish.repoName");
+        var repoUser = System.getProperty("edc.publish.user");
+        var repoPwd = System.getProperty("edc.publish.password");
+
+
+        if (repoUrl == null || repoName == null) return null;
+
+        return handler -> handler.maven(repo -> {
+            repo.setUrl(repoUrl);
+            repo.credentials(cred -> {
+                cred.setUsername(repoUser);
+                cred.setPassword(repoPwd);
+            });
+            repo.setAllowInsecureProtocol(repoUrl.startsWith("http://"));
+            repo.setName(repoName);
+        });
     }
 
 

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/NexusPublishingConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/NexusPublishingConvention.java
@@ -20,12 +20,17 @@ import org.gradle.api.Project;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Repositories.sonatypeRepo;
 
 class NexusPublishingConvention implements EdcConvention {
+
     @Override
     public void apply(Project target) {
         if (target == target.getRootProject()) {
+
+
             target.getExtensions().configure(NexusPublishExtension.class, nexusPublishExtension -> {
                 nexusPublishExtension.repositories(sonatypeRepo());
             });
         }
     }
+
+
 }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/Repositories.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/Repositories.java
@@ -17,9 +17,7 @@ package org.eclipse.edc.plugins.edcbuild.conventions;
 import io.github.gradlenexus.publishplugin.NexusRepository;
 import io.github.gradlenexus.publishplugin.NexusRepositoryContainer;
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.api.artifacts.repositories.PasswordCredentials;
 
 import java.net.URI;
 
@@ -27,28 +25,14 @@ public class Repositories {
 
     public static final String REPO_NAME_SONATYPE = "OSSRH";
     public static final String SNAPSHOT_REPO_URL = "https://oss.sonatype.org/content/repositories/snapshots/";
-    public static final String RELEASE_REPO_URL = "https://oss.sonatype.org/service/local/staging/deploy/maven2/";
     public static final String NEXUS_REPO_URL = "https://oss.sonatype.org/service/local/";
     private static final String OSSRH_PASSWORD = "OSSRH_PASSWORD";
     private static final String OSSRH_USER = "OSSRH_USER";
 
-    public static Action<MavenArtifactRepository> mavenRepo(String snapshotRepoUrl) {
+    public static Action<MavenArtifactRepository> mavenRepo(String repoUrl) {
         return repo -> {
-            repo.setUrl(snapshotRepoUrl);
-            repo.setName(REPO_NAME_SONATYPE);
-            repo.credentials(PasswordCredentials.class, creds -> {
-                creds.setPassword(System.getenv(OSSRH_PASSWORD));
-                creds.setUsername(System.getenv(OSSRH_USER));
-            });
+            repo.setUrl(repoUrl);
         };
-    }
-
-    public static Action<? super RepositoryHandler> snapshotRepo() {
-        return handler -> handler.maven(mavenRepo(SNAPSHOT_REPO_URL));
-    }
-
-    public static Action<? super RepositoryHandler> releaseRepo() {
-        return handler -> handler.maven(mavenRepo(RELEASE_REPO_URL));
     }
 
     public static Action<? super NexusRepositoryContainer> sonatypeRepo() {

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/BuildExtension.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/BuildExtension.java
@@ -60,6 +60,7 @@ public abstract class BuildExtension {
     public SwaggerGeneratorExtension getSwagger() {
         return swagger;
     }
-    
+
     public abstract Property<Boolean> getPublish();
+
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds a few CLI arguments which allow specifying the Maven repository via CLI parameters:
- `edc.publish.url`: the URL of the Maven repo
- `edc.publish.repoName`: the name of the repo. Relevant for the `publish...` command
- `edc.publish.username`: the repo username
- `edc.publish.password`: the repo password

For example we could publish to a Nexus Repository running on localhost via:
```bash
./gradlew  -Dedc.publish.repoName=foobar \                                                                                                                                                                                                        
 -Dedc.publish.url="http://localhost:8081/repository/maven-snapshots/" \
 -Dedc.publish.user=admin \
 -Dedc.publish.password=admin \
 publishAllPublicationsToFoobar
```

notice how the `edc.publis.repoName` is inserted into the `publish` command.

## Why it does that

conveniently publish artifacts to a custom maven repo instance.

## Further notes

This will add a plain Maven repository. Publishing to Sonatype Nexus is special in many ways, so this will be kept separate for now.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
