### PR TITLE
fix: Revert "chore: upgrade to Gradle 8.0 (#89)"

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugins/autodoc/autodoc-plugin/build.gradle.kts
+++ b/plugins/autodoc/autodoc-plugin/build.gradle.kts
@@ -19,9 +19,6 @@ val assertj: String by project
 val groupId: String by project
 
 gradlePlugin {
-    website.set("https://projects.eclipse.org/proposals/eclipse-dataspace-connector")
-    vcsUrl.set("https://github.com/eclipse-dataspaceconnector/GradlePlugins.git")
-
     // Define the plugin
     plugins {
         create("autodoc") {
@@ -30,7 +27,13 @@ gradlePlugin {
                 "Plugin to generate a documentation manifest for the EDC Metamodel, i.e. extensions, SPIs, etc."
             id = "${groupId}.autodoc"
             implementationClass = "org.eclipse.edc.plugins.autodoc.AutodocPlugin"
-            tags.set(listOf("build", "documentation", "generated", "autodoc"))
         }
     }
+}
+
+pluginBundle {
+    website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
+    vcsUrl = "https://github.com/eclipse-dataspaceconnector/GradlePlugins.git"
+    version = version
+    tags = listOf("build", "documentation", "generated", "autodoc")
 }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocDependencyInjector.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocDependencyInjector.java
@@ -47,16 +47,7 @@ class AutodocDependencyInjector implements DependencyResolutionListener {
 
     @Override
     public void beforeResolve(ResolvableDependencies dependencies) {
-        var version = versionSupplier.get();
-
-        var artifact = dependencyName;
-        if (version != null) {
-            artifact += ":" + version;
-        } else {
-            artifact += ":+";
-            project.getLogger().warn("No explicit configuration value for the annotationProcessor version was found. Please supply a configuration for the Autodoc Plugin's annotationProcessor.");
-        }
-
+        var artifact = dependencyName + versionSupplier.get();
         if (addDependency(project, artifact)) {
             var task = project.getTasks().findByName("compileJava");
             if ((task instanceof JavaCompile)) {

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.plugins.autodoc;
 import org.eclipse.edc.plugins.autodoc.merge.MergeManifestsTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 
 import java.io.File;
 import java.util.function.Supplier;
@@ -38,7 +40,7 @@ public class AutodocPlugin implements Plugin<Project> {
         project.getExtensions().create("autodocextension", AutodocExtension.class);
 
         // adds the annotation processor dependency
-        project.getGradle().addListener(new AutodocDependencyInjector(project, format("%s:%s", GROUP_NAME, PROCESSOR_ARTIFACT_NAME),
+        project.getGradle().addListener(new AutodocDependencyInjector(project, format("%s:%s:", GROUP_NAME, PROCESSOR_ARTIFACT_NAME),
                 createVersionProvider(project),
                 getOutputDirectoryProvider(project)));
 
@@ -62,14 +64,26 @@ public class AutodocPlugin implements Plugin<Project> {
     private Supplier<String> createVersionProvider(Project project) {
         return () -> {
             // runtime version of the actual annotation processor, or override in config
+            var versionToUse = getProcessorModuleVersion(project);
 
             var extension = project.getExtensions().findByType(AutodocExtension.class);
             if (extension != null && extension.getProcessorVersion().isPresent()) {
-                var versionToUse = extension.getProcessorVersion().get();
+                versionToUse = extension.getProcessorVersion().get();
                 project.getLogger().debug("{}: use configured version from AutodocExtension (override) [{}]", project.getName(), versionToUse);
-                return versionToUse;
+            } else {
+                project.getLogger().debug("{}: use default version [{}]", project.getName(), versionToUse);
             }
-            return null;
+            return versionToUse;
         };
+    }
+
+    private String getProcessorModuleVersion(Project project) {
+        Configuration classpath = project.getRootProject().getBuildscript().getConfigurations().getByName("classpath");
+        return classpath.getResolvedConfiguration().getResolvedArtifacts().stream()
+                .map(artifact -> artifact.getModuleVersion().getId())
+                .filter(id -> GROUP_NAME.equals(id.getGroup()) && PLUGIN_ARTIFACT_NAME.equals(id.getName()))
+                .findAny()
+                .map(ModuleVersionIdentifier::getVersion)
+                .orElse(null);
     }
 }

--- a/plugins/edc-build/build.gradle.kts
+++ b/plugins/edc-build/build.gradle.kts
@@ -27,8 +27,6 @@ dependencies {
 }
 
 gradlePlugin {
-    website.set("https://projects.eclipse.org/proposals/eclipse-dataspace-connector")
-    vcsUrl.set("https://github.com/eclipse-dataspaceconnector/GradlePlugins.git")
     // Define the plugins
     plugins {
         create("edc-build-base") {
@@ -37,7 +35,6 @@ gradlePlugin {
                 "Meta-plugin that provides the capabilities of the EDC build"
             id = "${groupId}.edc-build-base"
             implementationClass = "org.eclipse.edc.plugins.edcbuild.EdcBuildBasePlugin"
-            tags.set(listOf("build", "verification", "test"))
         }
         create("edc-build") {
             displayName = "edc-build"
@@ -45,7 +42,13 @@ gradlePlugin {
                 "Plugin that applies the base capabilities and provides default configuration for the EDC build"
             id = "${groupId}.edc-build"
             implementationClass = "org.eclipse.edc.plugins.edcbuild.EdcBuildPlugin"
-            tags.set(listOf("build", "verification", "test"))
         }
     }
+}
+
+pluginBundle {
+    website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
+    vcsUrl = "https://github.com/eclipse-dataspaceconnector/GradlePlugins.git"
+    version = version
+    tags = listOf("build", "verification", "test")
 }

--- a/plugins/module-names/build.gradle.kts
+++ b/plugins/module-names/build.gradle.kts
@@ -8,8 +8,6 @@ val assertj: String by project
 val groupId: String by project
 
 gradlePlugin {
-    website.set("https://projects.eclipse.org/proposals/eclipse-dataspace-connector")
-    vcsUrl.set("https://github.com/eclipse-dataspaceconnector/GradlePlugins.git")
     // Define the plugin
     plugins {
         create("module-names") {
@@ -18,8 +16,13 @@ gradlePlugin {
                 "Plugin to verify that a project has no duplicate submodules (by name)"
             id = "${groupId}.module-names"
             implementationClass = "org.eclipse.edc.plugins.modulenames.ModuleNamesPlugin"
-            tags.set(listOf("build", "verification"))
-            version = version
         }
     }
+}
+
+pluginBundle {
+    website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
+    vcsUrl = "https://github.com/eclipse-dataspaceconnector/GradlePlugins.git"
+    version = version
+    tags = listOf("build", "verification")
 }

--- a/plugins/openapi-merger/build.gradle.kts
+++ b/plugins/openapi-merger/build.gradle.kts
@@ -15,8 +15,6 @@ dependencies {
 }
 
 gradlePlugin {
-    website.set("https://projects.eclipse.org/proposals/eclipse-dataspace-connector")
-    vcsUrl.set("https://github.com/eclipse-dataspaceconnector/GradlePlugins.git")
     // Define the plugin
     plugins {
         create("openapi-merger") {
@@ -25,7 +23,13 @@ gradlePlugin {
                 "Plugin to several OpenAPI spec files into one"
             id = "${groupId}.openapi-merger"
             implementationClass = "org.eclipse.edc.plugins.openapimerger.OpenApiMergerPlugin"
-            tags.set(listOf("build", "openapi", "merge", "documentation"))
         }
     }
+}
+
+pluginBundle {
+    website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
+    vcsUrl = "https://github.com/eclipse-dataspaceconnector/GradlePlugins.git"
+    version = version
+    tags = listOf("build", "openapi", "merge", "documentation")
 }

--- a/plugins/test-summary/build.gradle.kts
+++ b/plugins/test-summary/build.gradle.kts
@@ -8,9 +8,6 @@ val assertj: String by project
 val groupId: String by project
 
 gradlePlugin {
-    website.set("https://projects.eclipse.org/proposals/eclipse-dataspace-connector")
-    vcsUrl.set("https://github.com/eclipse-dataspaceconnector/GradlePlugins.git")
-
     // Define the plugin
     plugins {
         create("test-summary") {
@@ -19,7 +16,13 @@ gradlePlugin {
                 "Plugin to verify that a project has no duplicate submodules (by name)"
             id = "${groupId}.test-summary"
             implementationClass = "org.eclipse.edc.plugins.testsummary.TestSummaryPlugin"
-            tags.set(listOf("build", "verification", "test"))
         }
     }
+}
+
+pluginBundle {
+    website = "https://projects.eclipse.org/proposals/eclipse-dataspace-connector"
+    vcsUrl = "https://github.com/eclipse-dataspaceconnector/GradlePlugins.git"
+    version = version
+    tags = listOf("build", "verification", "test")
 }


### PR DESCRIPTION
This reverts commit 5a821e3c9cab752c40e9162190ec800c183b8277.

## What this PR changes/adds

Reverts gradle upgrade and set it back to 7.6

## Why it does that

Gradle 8 impediment for #85 because, making the edc-build calling itself is causing gradle to fail with a dependency error that [seems to be related to the nexus-publish plugin](https://github.com/gradle-nexus/publish-plugin/issues/208)

## Further notes

-

## Linked Issue(s)


## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
