### PR TITLE
fix: use gradle 'group' property instead of 'groupId'

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,12 +8,11 @@ plugins {
     alias(libs.plugins.publish) apply false
 }
 
-val groupId: String by project
+val group: String by project
 val annotationProcessorVersion: String by project
 
 allprojects {
-    apply(plugin = "org.eclipse.edc.edc-build")
-    group = groupId
+    apply(plugin = "${group}.edc-build")
 
     configure<org.eclipse.edc.plugins.autodoc.AutodocExtension> {
         processorVersion.set(annotationProcessorVersion)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
-groupId=org.eclipse.edc
+group=org.eclipse.edc
 version=0.0.1-SNAPSHOT
+
 annotationProcessorVersion=0.0.1-SNAPSHOT

--- a/plugins/autodoc/autodoc-plugin/build.gradle.kts
+++ b/plugins/autodoc/autodoc-plugin/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     implementation(libs.jackson.datatypeJsr310)
 }
 
-val groupId: String by project
+val group: String by project
 
 gradlePlugin {
     website.set("https://projects.eclipse.org/projects/technology.edc")
@@ -22,7 +22,7 @@ gradlePlugin {
             displayName = "autodoc"
             description =
                 "Plugin to generate a documentation manifest for the EDC Metamodel, i.e. extensions, SPIs, etc."
-            id = "${groupId}.autodoc"
+            id = "${group}.autodoc"
             implementationClass = "org.eclipse.edc.plugins.autodoc.AutodocPlugin"
             tags.set(listOf("build", "documentation", "generated", "autodoc"))
         }

--- a/plugins/edc-build/README.md
+++ b/plugins/edc-build/README.md
@@ -18,5 +18,4 @@ This module contains a Gradle Plugin, that acts as a "meta-plugin" of sorts, bec
   Note that the `edc.publish.repoName=foobar` is important, because it will define actual
   command `publishAllPublicationsToFoobar`
 - performs general configuration, e.g. adding standard dependencies to all projects
-- applies the `groupId`
 - applies all values for the signing config, e.g. developer name, etc.

--- a/plugins/edc-build/build.gradle.kts
+++ b/plugins/edc-build/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     `java-gradle-plugin`
 }
 
-val groupId: String by project
+val group: String by project
 
 repositories {
     mavenCentral()
@@ -32,7 +32,7 @@ gradlePlugin {
             displayName = "edc-build-base"
             description =
                 "Meta-plugin that provides the capabilities of the EDC build"
-            id = "${groupId}.edc-build-base"
+            id = "${group}.edc-build-base"
             implementationClass = "org.eclipse.edc.plugins.edcbuild.EdcBuildBasePlugin"
             tags.set(listOf("build", "verification", "test"))
         }
@@ -40,7 +40,7 @@ gradlePlugin {
             displayName = "edc-build"
             description =
                 "Plugin that applies the base capabilities and provides default configuration for the EDC build"
-            id = "${groupId}.edc-build"
+            id = "${group}.edc-build"
             implementationClass = "org.eclipse.edc.plugins.edcbuild.EdcBuildPlugin"
             tags.set(listOf("build", "verification", "test"))
         }

--- a/plugins/module-names/build.gradle.kts
+++ b/plugins/module-names/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     `java-gradle-plugin`
 }
 
-val groupId: String by project
+val group: String by project
 
 gradlePlugin {
     website.set("https://projects.eclipse.org/projects/technology.edc")
@@ -13,7 +13,7 @@ gradlePlugin {
             displayName = "module-names"
             description =
                 "Plugin to verify that a project has no duplicate submodules (by name)"
-            id = "${groupId}.module-names"
+            id = "${group}.module-names"
             implementationClass = "org.eclipse.edc.plugins.modulenames.ModuleNamesPlugin"
             tags.set(listOf("build", "verification"))
             version = version

--- a/plugins/openapi-merger/build.gradle.kts
+++ b/plugins/openapi-merger/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     `java-gradle-plugin`
 }
 
-val groupId: String by project
+val group: String by project
 
 dependencies {
     // contains the actual merger task
@@ -20,7 +20,7 @@ gradlePlugin {
             displayName = "openapi-merger"
             description =
                 "Plugin to several OpenAPI spec files into one"
-            id = "${groupId}.openapi-merger"
+            id = "${group}.openapi-merger"
             implementationClass = "org.eclipse.edc.plugins.openapimerger.OpenApiMergerPlugin"
             tags.set(listOf("build", "openapi", "merge", "documentation"))
         }

--- a/plugins/test-summary/build.gradle.kts
+++ b/plugins/test-summary/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     `java-gradle-plugin`
 }
 
-val groupId: String by project
+val group: String by project
 
 gradlePlugin {
     website.set("https://projects.eclipse.org/projects/technology.edc")
@@ -14,7 +14,7 @@ gradlePlugin {
             displayName = "test-summary"
             description =
                 "Plugin to verify that a project has no duplicate submodules (by name)"
-            id = "${groupId}.test-summary"
+            id = "${group}.test-summary"
             implementationClass = "org.eclipse.edc.plugins.testsummary.TestSummaryPlugin"
             tags.set(listOf("build", "verification", "test"))
         }


### PR DESCRIPTION
## What this PR changes/adds

As documented in
https://docs.gradle.org/current/dsl/org.gradle.api.Project.html#org.gradle.api.Project:group

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
