### PR TITLE
fix: supply Jackson Dataformat XML libs alongside azure

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ fraunhofer-infomodel = { module = "de.fraunhofer.iais.eis.ids.infomodel:java", v
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-dataformat-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
 jackson-datatypeJsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 jakarta-validation = { module = "jakarta.validation:jakarta.validation-api", version.ref = "jakartaValidation" }
 jakarta-rsApi = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "rsApi" }
@@ -65,7 +66,7 @@ jersey-servlet = { module = "org.glassfish.jersey.containers:jersey-container-se
 jersey-servletcore = { module = "org.glassfish.jersey.containers:jersey-container-servlet-core", version.ref = "jersey" }
 jersey-jackson = { module = "org.glassfish.jersey.media:jersey-media-json-jackson", version.ref = "jersey" }
 jersey-inject = { module = "org.glassfish.jersey.inject:jersey-hk2", version.ref = "jersey" }
-jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotation"}
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotation" }
 jetty-websocket = { module = "org.eclipse.jetty.websocket:websocket-jakarta-server", version.ref = "jetty" }
 jta = { module = "javax.transaction:javax.transaction-api", version.ref = "jta" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiter" }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DefaultDependencyConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DefaultDependencyConvention.java
@@ -46,6 +46,10 @@ class DefaultDependencyConvention implements EdcConvention {
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-core:%s", jacksonVersion));
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-annotations:%s", jacksonVersion));
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-databind:%s", jacksonVersion));
+            // this is a temporary workaround to compensate for azure libs, that use XmlMapper, but don't correctly list it as a dependency
+            if (hasAzureDependency(target)) {
+                d.add(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, format("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:%s", jacksonVersion));
+            }
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:%s", jacksonVersion));
             d.add(JavaPlugin.API_CONFIGURATION_NAME, format("%s:runtime-metamodel:%s", EDC_GROUP_ID, ext.getMetaModel().getOrElse("0.0.1-SNAPSHOT")));
 
@@ -57,6 +61,11 @@ class DefaultDependencyConvention implements EdcConvention {
             d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.mockito:mockito-core:%s", ext.getMockito().getOrElse(catalogReader.versionFor("mockito", "5.2.0"))));
             d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.assertj:assertj-core:%s", ext.getAssertJ().getOrElse(catalogReader.versionFor("assertj", "3.23.1"))));
         });
+    }
+
+    private boolean hasAzureDependency(Project target) {
+        return target.getConfigurations().stream().flatMap(c -> c.getDependencies().stream())
+                .anyMatch(d -> d.getGroup() != null && d.getGroup().contains("azure"));
     }
 
     private static class CatalogReader {


### PR DESCRIPTION
## What this PR changes/adds

This PR automatically adds the `com.fasterxml.jackson.dataformat:jackson-dataformat-xml` library to a project, if that projects depends on any Azure lib.

## Why it does that

There is an apparent but with `com.azure.core`, which attempts to instantiate an `XmlMapper`, but does not declare the appropriate dependency. Whether this is by design or by mistake is not known.

## Further notes

The matching criterion for the dependency check is `<DEPENDENCYGROUP>.contains("azure")` because some groups are `com.microsoft.azure`, or `com.azure` etc.

## Linked Issue(s)

.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
