### PR TITLE
fix: avoid NPE on DefaultDependencyConvention

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DefaultDependencyConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DefaultDependencyConvention.java
@@ -17,12 +17,19 @@ package org.eclipse.edc.plugins.edcbuild.conventions;
 import org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.internal.catalog.AbstractExternalDependencyFactory;
 import org.gradle.api.internal.catalog.DefaultVersionCatalog;
+import org.gradle.api.internal.catalog.VersionModel;
 import org.gradle.api.plugins.JavaPlugin;
+
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.requireExtension;
+import static org.gradle.api.plugins.JavaPlugin.API_CONFIGURATION_NAME;
+import static org.gradle.api.plugins.JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME;
+import static org.gradle.api.plugins.JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME;
 
 /**
  * Applies default dependencies to all "java-library" projects, i.e. Jackson, the runtime-metamodel, JUnit, Mockito and AssertJ in
@@ -31,6 +38,12 @@ import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.r
 class DefaultDependencyConvention implements EdcConvention {
 
     private static final String EDC_GROUP_ID = "org.eclipse.edc";
+    private static final String DEFAULT_JETBRAINS_ANNOTATION_VERSION = "24.0.1";
+    private static final String DEFAULT_JACKSON_VERSION = "2.14.2";
+    private static final String DEFAULT_METAMODEL_VERSION = "0.0.1-SNAPSHOT";
+    private static final String DEFAULT_MOCKITO_VERSION = "5.2.0";
+    private static final String DEFAULT_ASSERTJ_VERSION = "3.23.1";
+    private static final String DEFAULT_JUPITER_VERSION = "5.9.2";
 
     @Override
     public void apply(Project target) {
@@ -38,28 +51,32 @@ class DefaultDependencyConvention implements EdcConvention {
 
             var ext = requireExtension(target, BuildExtension.class).getVersions();
             var catalogReader = new CatalogReader(target, ext.getCatalogName());
+            var d = target.getDependencies();
 
             // classpath dependencies
-            var d = target.getDependencies();
-            d.add(JavaPlugin.API_CONFIGURATION_NAME, format("org.jetbrains:annotations:%s", ext.getJetbrainsAnnotation().getOrElse(catalogReader.versionFor("jetbrainsAnnotation", "15.0"))));
-            var jacksonVersion = ext.getJackson().getOrElse(catalogReader.versionFor("jackson", "2.14.0"));
-            d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-core:%s", jacksonVersion));
-            d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-annotations:%s", jacksonVersion));
-            d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-databind:%s", jacksonVersion));
+            var jetbrainsAnnotationVersion = ext.getJetbrainsAnnotation().getOrElse(catalogReader.versionFor("jetbrainsAnnotation", DEFAULT_JETBRAINS_ANNOTATION_VERSION));
+            var jacksonVersion = ext.getJackson().getOrElse(catalogReader.versionFor("jackson", DEFAULT_JACKSON_VERSION));
+            var metamodelVersion = ext.getMetaModel().getOrElse(DEFAULT_METAMODEL_VERSION);
+            d.add(API_CONFIGURATION_NAME, format("org.jetbrains:annotations:%s", jetbrainsAnnotationVersion));
+            d.add(API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-core:%s", jacksonVersion));
+            d.add(API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-annotations:%s", jacksonVersion));
+            d.add(API_CONFIGURATION_NAME, format("com.fasterxml.jackson.core:jackson-databind:%s", jacksonVersion));
             // this is a temporary workaround to compensate for azure libs, that use XmlMapper, but don't correctly list it as a dependency
             if (hasAzureDependency(target)) {
                 d.add(JavaPlugin.RUNTIME_ONLY_CONFIGURATION_NAME, format("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:%s", jacksonVersion));
             }
-            d.add(JavaPlugin.API_CONFIGURATION_NAME, format("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:%s", jacksonVersion));
-            d.add(JavaPlugin.API_CONFIGURATION_NAME, format("%s:runtime-metamodel:%s", EDC_GROUP_ID, ext.getMetaModel().getOrElse("0.0.1-SNAPSHOT")));
+            d.add(API_CONFIGURATION_NAME, format("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:%s", jacksonVersion));
+            d.add(API_CONFIGURATION_NAME, format("%s:runtime-metamodel:%s", EDC_GROUP_ID, metamodelVersion));
 
             //test classpath dependencies
-            var jupiterVersion = ext.getJupiter().getOrElse(catalogReader.versionFor("jupiter", "5.9.2"));
-            d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.junit.jupiter:junit-jupiter-api:%s", jupiterVersion));
-            d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.junit.jupiter:junit-jupiter-params:%s", jupiterVersion));
-            d.add(JavaPlugin.TEST_RUNTIME_ONLY_CONFIGURATION_NAME, format("org.junit.jupiter:junit-jupiter-engine:%s", jupiterVersion));
-            d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.mockito:mockito-core:%s", ext.getMockito().getOrElse(catalogReader.versionFor("mockito", "5.2.0"))));
-            d.add(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.assertj:assertj-core:%s", ext.getAssertJ().getOrElse(catalogReader.versionFor("assertj", "3.23.1"))));
+            var jupiterVersion = ext.getJupiter().getOrElse(catalogReader.versionFor("jupiter", DEFAULT_JUPITER_VERSION));
+            var mockitoVersion = ext.getMockito().getOrElse(catalogReader.versionFor("mockito", DEFAULT_MOCKITO_VERSION));
+            var assertjVersion = ext.getAssertJ().getOrElse(catalogReader.versionFor("assertj", DEFAULT_ASSERTJ_VERSION));
+            d.add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.junit.jupiter:junit-jupiter-api:%s", jupiterVersion));
+            d.add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.junit.jupiter:junit-jupiter-params:%s", jupiterVersion));
+            d.add(TEST_RUNTIME_ONLY_CONFIGURATION_NAME, format("org.junit.jupiter:junit-jupiter-engine:%s", jupiterVersion));
+            d.add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.mockito:mockito-core:%s", mockitoVersion));
+            d.add(TEST_IMPLEMENTATION_CONFIGURATION_NAME, format("org.assertj:assertj-core:%s", assertjVersion));
         });
     }
 
@@ -88,8 +105,11 @@ class DefaultDependencyConvention implements EdcConvention {
                 var field = AbstractExternalDependencyFactory.class.getDeclaredField(FIELDNAME_CONFIG);
                 field.setAccessible(true);
                 var catalog = (DefaultVersionCatalog) field.get(factory);
-                var versionModel = catalog.getVersion(versionRef);
-                return versionModel.getVersion().getRequiredVersion();
+                return Optional.ofNullable(catalog)
+                        .map(c -> c.getVersion(versionRef))
+                        .map(VersionModel::getVersion)
+                        .map(VersionConstraint::getRequiredVersion)
+                        .orElse(defaultValue);
             } catch (IllegalAccessException | NoSuchFieldException e) {
                 throw new GradleException("error introspecting catalog", e);
             }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
@@ -56,6 +56,8 @@ public class MavenPublicationConvention implements EdcConvention {
                         mavenPublication -> {
                             mavenPublication.from(target.getComponents().getByName("java"));
                             mavenPublication.setGroupId(buildExt.getPom().getGroupId());
+                            mavenPublication.suppressPomMetadataWarningsFor("testFixturesApiElements");
+                            mavenPublication.suppressPomMetadataWarningsFor("testFixturesRuntimeElements");
                         }));
             }
         }


### PR DESCRIPTION
## What this PR changes/adds

Use null safe code to get version from the catalog

## Why it does that

Avoid NPE

## Further notes

- suppressed annoying "text-fixtures" warning on publication

## Linked Issue(s)

Closes #126

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
