### PR TITLE
chore: remove unused gatling dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ aws = "2.20.39"
 bouncyCastle-jdk18on = "1.72"
 cloudEvents = "2.4.2"
 failsafe = "3.3.1"
-gatling = "3.7.5"
 googleCloudIamAdmin = "1.2.5"
 googleCloudIamCredentials = "2.14.0"
 googleCloudStorage = "2.21.0"
@@ -46,7 +45,6 @@ bouncyCastle-bcpkixJdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", versi
 cloudEvents = { module = "io.cloudevents:cloudevents-http-basic", version.ref = "cloudEvents" }
 failsafe-core = { module = "dev.failsafe:failsafe", version.ref = "failsafe" }
 failsafe-okhttp = { module = "dev.failsafe:failsafe-okhttp", version.ref = "failsafe" }
-gatling = { module = "io.gatling.highcharts:gatling-charts-highcharts", version.ref = "gatling" }
 h2 = { module = "com.h2database:h2", version.ref = "h2" }
 mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "httpMockServer" }
 mockserver-client = { module = "org.mock-server:mockserver-client-java", version.ref = "httpMockServer" }

--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessor.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessor.java
@@ -63,7 +63,7 @@ import static javax.tools.Diagnostic.Kind.NOTE;
         "org.eclipse.edc.runtime.metamodel.annotation.Inject",
 })
 @SupportedSourceVersion(SourceVersion.RELEASE_11)
-@SupportedOptions({ EdcModuleProcessor.ID, EdcModuleProcessor.VERSION })
+@SupportedOptions({ EdcModuleProcessor.ID, EdcModuleProcessor.VERSION, EdcModuleProcessor.EDC_OUTPUTDIR_OVERRIDE })
 public class EdcModuleProcessor extends AbstractProcessor {
     public static final String VERSION = "edc.version";
     public static final String ID = "edc.id";


### PR DESCRIPTION
## What this PR changes/adds

Removes `gatling` version from catalog

## Why it does that

It's not used anymore.

## Further notes

- add `EdcModuleProcessor.EDC_OUTPUTDIR_OVERRIDE` as supported option, this will avoid some warnings

## Linked Issue(s)

Closes #139 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
