### PR TITLE
feat: set pom information defaults

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,12 @@ allprojects {
         apply(plugin = "com.gradle.plugin-publish")
     }
 
+    configure<org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension> {
+        pom {
+            githubOrgRepo.set("eclipse-edc/GradlePlugins")
+        }
+    }
+
     tasks.withType<Test> {
         useJUnitPlatform()
         testLogging {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 
 val group: String by project
 val annotationProcessorVersion: String by project
+val edcScmUrl: String by project
+val edcScmConnection: String by project
 
 allprojects {
     apply(plugin = "${group}.edc-build")
@@ -26,7 +28,8 @@ allprojects {
 
     configure<org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension> {
         pom {
-            githubOrgRepo.set("eclipse-edc/GradlePlugins")
+            scmUrl.set(edcScmUrl)
+            scmConnection.set(edcScmConnection)
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,7 @@
 group=org.eclipse.edc
 version=0.0.1-SNAPSHOT
 
+edcScmUrl=https://github.com/eclipse-edc/GradlePlugins
+edcScmConnection=scm:git:git@github.com:eclipse-edc/GradlePlugins.git
+
 annotationProcessorVersion=0.0.1-SNAPSHOT

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenArtifactConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenArtifactConvention.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Microsoft Corporation
+ *  Copyright (c) 2022 - 2023 Microsoft Corporation
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  */
 
@@ -21,6 +22,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPom;
 import org.gradle.api.publish.maven.MavenPublication;
 
 import java.nio.file.Path;
@@ -35,6 +37,9 @@ import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.r
  * </ul>
  */
 class MavenArtifactConvention implements EdcConvention {
+
+    private static final String PROJECT_URL = "https://projects.eclipse.org/projects/technology.edc";
+
     @Override
     public void apply(Project target) {
         target.afterEvaluate(project -> {
@@ -44,7 +49,7 @@ class MavenArtifactConvention implements EdcConvention {
             pubExt.getPublications().stream()
                     .filter(p -> p instanceof MavenPublication)
                     .map(p -> (MavenPublication) p)
-                    .peek(mavenPub -> addPomInformation(pomExt, mavenPub))
+                    .peek(mavenPub -> mavenPub.pom(pom -> setPomInformation(pomExt, target, pom)))
                     .forEach(mavenPub -> addManifestArtifact(target, mavenPub));
         });
     }
@@ -68,29 +73,34 @@ class MavenArtifactConvention implements EdcConvention {
         }
     }
 
-    private void addPomInformation(MavenPomExtension pomExt, MavenPublication mavenPub) {
-        mavenPub.pom(pom -> {
-            // these properties are mandatory!
-            pom.getName().set(pomExt.getProjectName());
-            pom.getDescription().set(pomExt.getDescription());
-            pom.getUrl().set(pomExt.getProjectUrl());
+    private static void setPomInformation(MavenPomExtension pomExt, Project project, MavenPom pom) {
+        // these properties are mandatory!
+        pom.getName().set(project.getName());
+        pom.getDescription().set("edc :: " + project.getName());
+        pom.getUrl().set(PROJECT_URL);
 
-            // we'll provide a sane default for these properties
-            pom.licenses(l -> l.license(pl -> {
-                pl.getName().set(pomExt.getLicenseName().getOrElse("The Apache License, Version 2.0"));
-                pl.getUrl().set(pomExt.getLicenseUrl().getOrElse("http://www.apache.org/licenses/LICENSE-2.0.txt"));
-            }));
+        // we'll provide a sane default for these properties
+        pom.licenses(l -> l.license(pl -> {
+            pl.getName().set(pomExt.getLicenseName().getOrElse("The Apache License, Version 2.0"));
+            pl.getUrl().set(pomExt.getLicenseUrl().getOrElse("http://www.apache.org/licenses/LICENSE-2.0.txt"));
+        }));
 
-            pom.developers(d -> d.developer(md -> {
-                md.getId().set(pomExt.getDeveloperId().getOrElse("mspiekermann"));
-                md.getName().set(pomExt.getDeveloperName().getOrElse("Markus Spiekermann"));
-                md.getEmail().set(pomExt.getDeveloperEmail().getOrElse("markus.spiekermann@isst.fraunhofer.de"));
-            }));
+        pom.developers(d -> d.developer(md -> {
+            md.getId().set(pomExt.getDeveloperId().getOrElse("mspiekermann"));
+            md.getName().set(pomExt.getDeveloperName().getOrElse("Markus Spiekermann"));
+            md.getEmail().set(pomExt.getDeveloperEmail().getOrElse("markus.spiekermann@isst.fraunhofer.de"));
+        }));
 
-            pom.scm(scm -> {
+        pom.scm(scm -> {
+            var githubOrgRepo = pomExt.getGithubOrgRepo();
+            if (githubOrgRepo.isPresent()) {
+                scm.getUrl().set("https://github.com/" + githubOrgRepo.get());
+                scm.getConnection().set("scm:git:git@github.com:" + githubOrgRepo.get() + ".git");
+            } else {
+                // deprecated way, will be removed in the future
                 scm.getUrl().set(pomExt.getScmUrl());
                 scm.getConnection().set(pomExt.getScmConnection());
-            });
+            }
         });
     }
 

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenArtifactConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenArtifactConvention.java
@@ -75,9 +75,12 @@ class MavenArtifactConvention implements EdcConvention {
 
     private static void setPomInformation(MavenPomExtension pomExt, Project project, MavenPom pom) {
         // these properties are mandatory!
-        pom.getName().set(project.getName());
-        pom.getDescription().set("edc :: " + project.getName());
-        pom.getUrl().set(PROJECT_URL);
+        var projectName = pomExt.getProjectName().getOrElse(project.getName());
+        var description = pomExt.getDescription().getOrElse("edc :: " + project.getName());
+        var projectUrl = pomExt.getProjectUrl().getOrElse(PROJECT_URL);
+        pom.getName().set(projectName);
+        pom.getDescription().set(description);
+        pom.getUrl().set(projectUrl);
 
         // we'll provide a sane default for these properties
         pom.licenses(l -> l.license(pl -> {
@@ -92,15 +95,8 @@ class MavenArtifactConvention implements EdcConvention {
         }));
 
         pom.scm(scm -> {
-            var githubOrgRepo = pomExt.getGithubOrgRepo();
-            if (githubOrgRepo.isPresent()) {
-                scm.getUrl().set("https://github.com/" + githubOrgRepo.get());
-                scm.getConnection().set("scm:git:git@github.com:" + githubOrgRepo.get() + ".git");
-            } else {
-                // deprecated way, will be removed in the future
-                scm.getUrl().set(pomExt.getScmUrl());
-                scm.getConnection().set(pomExt.getScmConnection());
-            }
+            scm.getUrl().set(pomExt.getScmUrl());
+            scm.getConnection().set(pomExt.getScmConnection());
         });
     }
 

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/MavenPomExtension.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/MavenPomExtension.java
@@ -19,13 +19,10 @@ import org.gradle.api.provider.Property;
 public abstract class MavenPomExtension {
     private final String groupId = "org.eclipse.edc";
 
-    @Deprecated(since = "milestone9")
     public abstract Property<String> getProjectName();
 
-    @Deprecated(since = "milestone9")
     public abstract Property<String> getDescription();
 
-    @Deprecated(since = "milestone9")
     public abstract Property<String> getProjectUrl();
 
     public abstract Property<String> getLicenseName();
@@ -38,19 +35,9 @@ public abstract class MavenPomExtension {
 
     public abstract Property<String> getDeveloperEmail();
 
-    @Deprecated(since = "milestone9")
     public abstract Property<String> getScmConnection();
 
-    @Deprecated(since = "milestone9")
     public abstract Property<String> getScmUrl();
-
-    /**
-     * Represent the org/repo string.
-     * E.g. it should be "eclipse-edc/Connector" for the connector project
-     *
-     * @return a property representing the GitHub org/repo
-     */
-    public abstract Property<String> getGithubOrgRepo();
 
     public String getGroupId() {
         return groupId;

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/MavenPomExtension.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/MavenPomExtension.java
@@ -17,12 +17,15 @@ package org.eclipse.edc.plugins.edcbuild.extensions;
 import org.gradle.api.provider.Property;
 
 public abstract class MavenPomExtension {
-    private String groupId = "org.eclipse.edc";
+    private final String groupId = "org.eclipse.edc";
 
+    @Deprecated(since = "milestone9")
     public abstract Property<String> getProjectName();
 
+    @Deprecated(since = "milestone9")
     public abstract Property<String> getDescription();
 
+    @Deprecated(since = "milestone9")
     public abstract Property<String> getProjectUrl();
 
     public abstract Property<String> getLicenseName();
@@ -35,16 +38,22 @@ public abstract class MavenPomExtension {
 
     public abstract Property<String> getDeveloperEmail();
 
+    @Deprecated(since = "milestone9")
     public abstract Property<String> getScmConnection();
 
+    @Deprecated(since = "milestone9")
     public abstract Property<String> getScmUrl();
+
+    /**
+     * Represent the org/repo string.
+     * E.g. it should be "eclipse-edc/Connector" for the connector project
+     *
+     * @return a property representing the GitHub org/repo
+     */
+    public abstract Property<String> getGithubOrgRepo();
 
     public String getGroupId() {
         return groupId;
-    }
-
-    public void setGroupId(String groupId) {
-        this.groupId = groupId;
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

Set pom information defaults to avoid having to set them on every project.

## Why it does that

simplify configuration

## Further notes

## Linked Issue(s)

Closes #130 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
