### PR TITLE
fix: re-add setter for grouId in the MavenPomExtension

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/MavenPomExtension.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/MavenPomExtension.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.plugins.edcbuild.extensions;
 import org.gradle.api.provider.Property;
 
 public abstract class MavenPomExtension {
-    private final String groupId = "org.eclipse.edc";
+    private String groupId = "org.eclipse.edc";
 
     public abstract Property<String> getProjectName();
 
@@ -43,4 +43,7 @@ public abstract class MavenPomExtension {
         return groupId;
     }
 
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

Re-adds a previously deleted setter for the `groupId` 

## Why it does that

Downstream projects could not override the group id

## Further notes

.
## Linked Issue(s)

Closes .

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
