### PR TITLE
build: switch default java version to 17

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,21 +33,10 @@ allprojects {
         }
     }
 
-    tasks.withType<Test> {
-        useJUnitPlatform()
-        testLogging {
-            showStandardStreams = true
-        }
-    }
-
     // configure checkstyle version
     checkstyle {
         toolVersion = "10.0"
         maxErrors = 0 // does not tolerate errors
-    }
-
-    repositories {
-        mavenCentral()
     }
 
     // let's not generate any reports because that is done from within the Github Actions workflow

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/JavaConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/JavaConvention.java
@@ -27,7 +27,7 @@ import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.r
  */
 class JavaConvention implements EdcConvention {
 
-    private static final int DEFAULT_JAVA_VERSION = 11;
+    private static final int DEFAULT_JAVA_VERSION = 17;
 
     @Override
     public void apply(Project target) {
@@ -53,4 +53,5 @@ class JavaConvention implements EdcConvention {
         javaPluginExt.withJavadocJar();
         javaPluginExt.withSourcesJar();
     }
+
 }


### PR DESCRIPTION
## What this PR changes/adds

Change default java version to 17.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- cleanup build file a little

## Linked Issue(s)

Closes #158 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
