### PR TITLE
build: update annotation processor source version to 17

### DIFF
--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessor.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessor.java
@@ -62,7 +62,7 @@ import static javax.tools.Diagnostic.Kind.NOTE;
         "org.eclipse.edc.runtime.metamodel.annotation.Requires",
         "org.eclipse.edc.runtime.metamodel.annotation.Inject",
 })
-@SupportedSourceVersion(SourceVersion.RELEASE_11)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 @SupportedOptions({ EdcModuleProcessor.ID, EdcModuleProcessor.VERSION, EdcModuleProcessor.EDC_OUTPUTDIR_OVERRIDE })
 public class EdcModuleProcessor extends AbstractProcessor {
     public static final String VERSION = "edc.version";


### PR DESCRIPTION
## What this PR changes/adds

update annotation processor source version to 17

## Why it does that

fix a warning

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

part of #158 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
