### PR TITLE
chore: update snapshot version to 0.1.0-SNAPSHOT

### DIFF
--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.1-SNAPSHOT
+version=0.1.0-SNAPSHOT

--- a/docs/legal/generateThirdPartyReport.sh
+++ b/docs/legal/generateThirdPartyReport.sh
@@ -7,7 +7,7 @@
 # The Eclipse Dash Licenses tool was executed and resulted in an file (e.g., NOTICES)
 # listing all dependencies of the project.
 # To process the dependencies of a specific module, execute the following command:
-#   gradle dependencies | grep -Poh "(?<=\s)[\w\.-]+:[\w\.-]+:[^:\s]+" | sort | uniq | java -jar /path/org.eclipse.dash.licenses-0.0.1-SNAPSHOT.jar - -summary NOTICES
+#   gradle dependencies | grep -Poh "(?<=\s)[\w\.-]+:[\w\.-]+:[^:\s]+" | sort | uniq | java -jar /path/org.eclipse.dash.licenses-<VERSION>.jar - -summary NOTICES
 #
 # Comments:
 # Gradle doesn't support listing all dependencies of a multi-module project out of the box.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=org.eclipse.edc
-version=0.0.1-SNAPSHOT
+version=0.1.0-SNAPSHOT
 
 edcScmUrl=https://github.com/eclipse-edc/GradlePlugins
 edcScmConnection=scm:git:git@github.com:eclipse-edc/GradlePlugins.git
 
-annotationProcessorVersion=0.0.1-SNAPSHOT
+annotationProcessorVersion=0.1.0-SNAPSHOT

--- a/plugins/autodoc/autodoc-plugin/build.gradle.kts
+++ b/plugins/autodoc/autodoc-plugin/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":runtime-metamodel"))
     implementation(libs.jetbrains.annotations)
     implementation(libs.jackson.core)
     implementation(libs.jackson.annotations)

--- a/plugins/edc-build/build.gradle.kts
+++ b/plugins/edc-build/build.gradle.kts
@@ -10,6 +10,7 @@ repositories {
 }
 
 dependencies {
+    implementation(project(":runtime-metamodel"))
     implementation(project(":plugins:autodoc:autodoc-plugin"))
     implementation(project(":plugins:test-summary"))
     implementation(project(":plugins:module-names"))

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DefaultDependencyConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/DefaultDependencyConvention.java
@@ -40,7 +40,7 @@ class DefaultDependencyConvention implements EdcConvention {
     private static final String EDC_GROUP_ID = "org.eclipse.edc";
     private static final String DEFAULT_JETBRAINS_ANNOTATION_VERSION = "24.0.1";
     private static final String DEFAULT_JACKSON_VERSION = "2.14.2";
-    private static final String DEFAULT_METAMODEL_VERSION = "0.0.1-SNAPSHOT";
+    private static final String DEFAULT_METAMODEL_VERSION = "0.1.0-SNAPSHOT";
     private static final String DEFAULT_MOCKITO_VERSION = "5.2.0";
     private static final String DEFAULT_ASSERTJ_VERSION = "3.23.1";
     private static final String DEFAULT_JUPITER_VERSION = "5.9.2";

--- a/plugins/module-names/build.gradle.kts
+++ b/plugins/module-names/build.gradle.kts
@@ -20,3 +20,7 @@ gradlePlugin {
         }
     }
 }
+
+dependencies {
+    implementation(project(":runtime-metamodel"))
+}

--- a/plugins/openapi-merger/build.gradle.kts
+++ b/plugins/openapi-merger/build.gradle.kts
@@ -9,6 +9,9 @@ dependencies {
     implementation(libs.plugin.openapi.merger)
     // needed for the OpenApiDataInvalidException:
     implementation(libs.plugin.openapi.merger.app)
+
+    implementation(project(":runtime-metamodel"))
+
 }
 
 gradlePlugin {

--- a/plugins/test-summary/build.gradle.kts
+++ b/plugins/test-summary/build.gradle.kts
@@ -20,3 +20,7 @@ gradlePlugin {
         }
     }
 }
+
+dependencies {
+    implementation(project(":runtime-metamodel"))
+}


### PR DESCRIPTION
## What this PR changes/adds

Update snapshot version to `0.1.0-SNAPSHOT`

## Why it does that

Our next release version will be `0.1.0`, thus the next snapshot will be `0.1.1-SNAPSHOT` and the automatic version bump mechanism currently only bumps the `patch` version.

## Further notes

- added `implementation` dependencies onto the `:runtime-metamodel` module, which seems to break the cycle

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
