### PR TITLE
feat: add DEPENDENCIES file to jars

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/JarConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/JarConvention.java
@@ -31,7 +31,8 @@ class JarConvention implements EdcConvention {
             var rootProjectPath = target.getRootProject().getProjectDir().getAbsolutePath();
             var licenseFile = Path.of(rootProjectPath, "LICENSE");
             var noticeFile = Path.of(rootProjectPath, "NOTICE.md");
-            jarTask.metaInf(metaInf -> metaInf.from(licenseFile.toString(), noticeFile.toString()));
+            var dependenciesFile = Path.of(rootProjectPath, "DEPENDENCIES");
+            jarTask.metaInf(metaInf -> metaInf.from(licenseFile.toString(), noticeFile.toString(), dependenciesFile.toString()));
         }
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds the `DEPENDENCIES` file to every jar we generate.

## Why it does that

Every artefact we distribute should contain license information and information about other software it uses.

## Further notes

Please note that this fix includes the `DEPENDENCIES` file _at root level_, which contains _all_ dependencies of a project. There seems to be no (easy) way to only include a subproject's dependencies, unless we actually create a Gradle Dash Plugin.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

\cc @SebastianBezold
