### PR TITLE
feat: add manifest-to-markdown renderer

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,23 +1,19 @@
 maven/mavencentral/com.autonomousapps/antlr/4.10.1.3, , restricted, clearlydefined
 maven/mavencentral/com.autonomousapps/asm-relocated/9.4.0.1, , restricted, clearlydefined
 maven/mavencentral/com.autonomousapps/dependency-analysis-gradle-plugin/1.20.0, , restricted, clearlydefined
-maven/mavencentral/com.autonomousapps/graph-support/0.1, , restricted, clearlydefined
+maven/mavencentral/com.autonomousapps/graph-support/0.1, Apache-2.0, approved, #9666
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.11.1, Apache-2.0, approved, CQ23491
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.2, Apache-2.0, approved, #5303
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.2, Apache-2.0, approved, #7947
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.14.2, Apache-2.0 AND MIT, approved, #4303
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.2, MIT AND Apache-2.0, approved, #7932
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.11.0, Apache-2.0, approved, CQ23093
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.11.1, Apache-2.0, approved, CQ23093
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.13.1, Apache-2.0, approved, #2134
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.2, Apache-2.0, approved, #4105
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.2, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.2.3, Apache-2.0 OR (Apache-2.0 AND LGPL-2.1), restricted, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.11.1, Apache-2.0, approved, CQ23094
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.13.1, Apache-2.0, approved, #2566
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.2, Apache-2.0, approved, #8802
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.11.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.2, Apache-2.0, approved, #4699
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.2, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.2, Apache-2.0, approved, #7929
 maven/mavencentral/com.fasterxml/classmate/1.3.1, Apache-2.0, approved, CQ10239
@@ -27,7 +23,7 @@ maven/mavencentral/com.github.fge/jackson-coreutils/1.6, Apache-2.0 or LGPL-3.0-
 maven/mavencentral/com.github.fge/jackson-coreutils/1.8, LGPL-3.0 OR Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.fge/json-patch/1.6, LGPL-3.0 OR Apache-2.0, restricted, clearlydefined
 maven/mavencentral/com.github.fge/msg-simple/1.1, Apache-2.0 OR LGPL-3.0-or-later, approved, #2574
-maven/mavencentral/com.github.fge/uri-template/0.9, (Apache-2.0 AND LGPL-3.0 AND LGPL-3.0-only) OR (Apache-2.0 AND LGPL-3.0-only), restricted, clearlydefined
+maven/mavencentral/com.github.fge/uri-template/0.9, Apache-2.0 OR LGPL-3.0-or-later, approved, #9668
 maven/mavencentral/com.github.java-json-tools/btf/1.3, Apache-2.0 OR LGPL-3.0-or-later, approved, #2721
 maven/mavencentral/com.github.java-json-tools/jackson-coreutils-equivalence/1.0, LGPL-3.0 OR Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.java-json-tools/jackson-coreutils/2.0, , approved, #2719
@@ -58,7 +54,7 @@ maven/mavencentral/com.googlecode.libphonenumber/libphonenumber/8.0.0, Apache-2.
 maven/mavencentral/com.googlecode.libphonenumber/libphonenumber/8.11.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.0, LGPL-2.1-or-later, approved, #7936
 maven/mavencentral/com.rameshkp/openapi-merger-app/1.0.5, , restricted, clearlydefined
-maven/mavencentral/com.rameshkp/openapi-merger-gradle-plugin/1.0.5, , restricted, clearlydefined
+maven/mavencentral/com.rameshkp/openapi-merger-gradle-plugin/1.0.5, Apache-2.0, approved, #9669
 maven/mavencentral/com.squareup.moshi/moshi-adapters/1.14.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.squareup.moshi/moshi-kotlin/1.14.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.squareup.moshi/moshi/1.14.0, Apache-2.0, approved, clearlydefined
@@ -73,7 +69,7 @@ maven/mavencentral/commons-io/commons-io/2.6, Apache-2.0, approved, CQ19090
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/dev.zacsweers.moshix/moshi-sealed-reflect/0.19.0, , restricted, clearlydefined
 maven/mavencentral/dev.zacsweers.moshix/moshi-sealed-runtime/0.19.0, , restricted, clearlydefined
-maven/mavencentral/gradle.plugin.org.gradle.crypto/checksum/1.4.0, , restricted, clearlydefined
+maven/mavencentral/gradle.plugin.org.gradle.crypto/checksum/1.4.0, Apache-2.0, approved, #9667
 maven/mavencentral/gradle.plugin.org.hidetake/gradle-swagger-generator-plugin/2.19.2, , restricted, clearlydefined
 maven/mavencentral/info.picocli/picocli/4.6.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.github.gradle-nexus/publish-plugin/1.3.0, , restricted, clearlydefined
@@ -109,6 +105,7 @@ maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause,
 maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.3, MIT, approved, CQ13174
 maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.4, MIT, approved, CQ13174
 maven/mavencentral/net.sf.saxon/Saxon-HE/10.6, MPL-2.0 AND W3C, approved, #7945
+maven/mavencentral/net.steppschuh.markdowngenerator/markdowngenerator/1.3.1.1, , restricted, clearlydefined
 maven/mavencentral/org.antlr/antlr4-runtime/4.9.3, BSD-3-Clause, approved, #322
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.2.1, Apache-2.0, approved, clearlydefined
@@ -132,7 +129,7 @@ maven/mavencentral/org.jacoco/org.jacoco.core/0.8.8, EPL-2.0, approved, CQ23283
 maven/mavencentral/org.jacoco/org.jacoco.report/0.8.8, EPL-2.0 AND Apache-2.0, approved, CQ23284
 maven/mavencentral/org.javassist/javassist/3.28.0-GA, Apache-2.0 OR LGPL-2.1-or-later OR MPL-1.1, approved, #327
 maven/mavencentral/org.jboss.logging/jboss-logging/3.3.0.Final, Apache-2.0, approved, CQ13772
-maven/mavencentral/org.jetbrains.kotlin/kotlin-bom/1.7.22, , restricted, clearlydefined
+maven/mavencentral/org.jetbrains.kotlin/kotlin-bom/1.7.22, Apache-2.0, approved, #9665
 maven/mavencentral/org.jetbrains.kotlin/kotlin-reflect/1.7.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains.kotlin/kotlin-reflect/1.7.20, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains.kotlin/kotlin-reflect/1.7.22, Apache-2.0, approved, clearlydefined

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(libs.jackson.datatypeJsr310)
 
     api(libs.edc.runtime.metamodel)
-
+    implementation(libs.markdown.gen)
 }
 
 gradlePlugin {
@@ -47,6 +47,7 @@ sourceSets {
             srcDirs(
                 "../plugins/autodoc/autodoc-plugin/src/main",
                 "../plugins/autodoc/autodoc-processor/src/main",
+                "../plugins/autodoc/autodoc-converters/src/main",
                 "../plugins/edc-build/src/main",
                 "../plugins/module-names/src/main",
                 "../plugins/openapi-merger/src/main",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,8 @@ plugin-openapi-merger-app = { module = "com.rameshkp:openapi-merger-app", versio
 plugin-swagger = { module = "io.swagger.core.v3:swagger-gradle-plugin", version = "2.2.10" }
 plugin-swagger-generator = { module = "gradle.plugin.org.hidetake:gradle-swagger-generator-plugin", version = "2.19.2" }
 
+# third party
+markdown-gen = { module = "net.steppschuh.markdowngenerator:markdowngenerator", version = "1.3.1.1" }
 [bundles]
 
 [plugins]

--- a/plugins/autodoc/autodoc-converters/README.md
+++ b/plugins/autodoc/autodoc-converters/README.md
@@ -1,0 +1,1 @@
+This module contains the business logic code for the `autodoc` feature, i.e. the actual annotation processor.

--- a/plugins/autodoc/autodoc-converters/build.gradle.kts
+++ b/plugins/autodoc/autodoc-converters/build.gradle.kts
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(libs.edc.runtime.metamodel)
+    implementation(libs.markdown.gen)
+}

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/json/JsonManifestReader.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/json/JsonManifestReader.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.autodoc.json;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.plugins.autodoc.spi.ManifestConverterException;
+import org.eclipse.edc.plugins.autodoc.spi.ManifestReader;
+import org.eclipse.edc.runtime.metamodel.domain.EdcModule;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+
+public class JsonManifestReader implements ManifestReader {
+    private static final TypeReference<List<EdcModule>> MODULE_TYPE_REF = new TypeReference<>() {
+    };
+    private final ObjectMapper objectMapper;
+
+    public JsonManifestReader(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<EdcModule> read(InputStream inputStream) {
+        try {
+            return objectMapper.readValue(new InputStreamReader(new BufferedInputStream(inputStream)), MODULE_TYPE_REF);
+        } catch (IOException e) {
+            throw new ManifestConverterException(e);
+        }
+    }
+}

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/json/JsonManifestReader.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/json/JsonManifestReader.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Microsoft Corporation
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRenderer.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRenderer.java
@@ -53,13 +53,13 @@ public class MarkdownManifestRenderer implements ManifestRenderer {
     }
 
     @Override
-    public void handleDocumentHeader() {
+    public void renderDocumentHeader() {
         stringBuilder.append(heading(DOCUMENT_HEADING, 1)).append(NEWLINE);
         stringBuilder.append(NEWLINE);
     }
 
     @Override
-    public void handleModuleHeading(@Nullable String moduleName, @NotNull String modulePath, @NotNull String version) {
+    public void renderModuleHeading(@Nullable String moduleName, @NotNull String modulePath, @NotNull String version) {
         var name = ofNullable(moduleName).orElse(modulePath);
 
         var moduleHeading = heading(format("Module `%s:%s`", name, version), 2);
@@ -72,7 +72,7 @@ public class MarkdownManifestRenderer implements ManifestRenderer {
     }
 
     @Override
-    public void handleModuleCategories(List<String> categories) {
+    public void renderCategories(List<String> categories) {
         // append categories as italic text
         var cat = categories
                 .stream()
@@ -88,7 +88,7 @@ public class MarkdownManifestRenderer implements ManifestRenderer {
     }
 
     @Override
-    public void handleExtensionPoints(List<Service> extensionPoints) {
+    public void renderExtensionPoints(List<Service> extensionPoints) {
         // append extension points
         stringBuilder.append(heading(EXTENSION_POINTS, 3)).append(NEWLINE);
         stringBuilder.append(listOrNone(unorderedList(extensionPoints.stream().map(s -> code(s.getService())).toList().toArray()))).append(NEWLINE);
@@ -96,12 +96,12 @@ public class MarkdownManifestRenderer implements ManifestRenderer {
     }
 
     @Override
-    public void handleExtensionHeading() {
+    public void renderExtensionHeading() {
         stringBuilder.append(heading(EXTENSIONS, 3)).append(NEWLINE);
     }
 
     @Override
-    public void handleExtensionHeader(@NotNull String className, String name, String overview, ModuleType type) {
+    public void renderExtensionHeader(@NotNull String className, String name, String overview, ModuleType type) {
         stringBuilder.append(heading("Class: " + code(className), 4)).append(NEWLINE);
 
         stringBuilder.append(bold("Name:")).append(format(" \"%s\"", name)).append(NEWLINE);
@@ -112,7 +112,7 @@ public class MarkdownManifestRenderer implements ManifestRenderer {
     }
 
     @Override
-    public void handleConfigurations(List<ConfigurationSetting> configuration) {
+    public void renderConfigurations(List<ConfigurationSetting> configuration) {
         // add configuration table
         var tableBuilder = new Table.Builder()
                 .addRow("Key", "Required", "Type", "Pattern", "Min", "Max", "Description");
@@ -135,7 +135,7 @@ public class MarkdownManifestRenderer implements ManifestRenderer {
     }
 
     @Override
-    public void handleExposedServices(List<Service> provides) {
+    public void renderExposedServices(List<Service> provides) {
         // add exposed services
         stringBuilder.append(heading("Provided services:", 5)).append(NEWLINE);
         stringBuilder.append(listOrNone(provides.stream().map(s -> code(s.getService())).toList().toArray())).append(NEWLINE);
@@ -143,7 +143,7 @@ public class MarkdownManifestRenderer implements ManifestRenderer {
     }
 
     @Override
-    public void handleReferencedServices(List<ServiceReference> references) {
+    public void renderReferencedServices(List<ServiceReference> references) {
         // add injected services
         stringBuilder.append(heading("Referenced (injected) services:", 5)).append(NEWLINE);
         stringBuilder.append(listOrNone(references.stream().map(s -> format("%s (%s)", code(s.getService()), s.isRequired() ? "required" : "optional")).toList().toArray())).append(NEWLINE);

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRenderer.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRenderer.java
@@ -1,0 +1,170 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.autodoc.markdown;
+
+import net.steppschuh.markdowngenerator.Markdown;
+import net.steppschuh.markdowngenerator.MarkdownElement;
+import net.steppschuh.markdowngenerator.table.Table;
+import org.eclipse.edc.plugins.autodoc.spi.ManifestConverterException;
+import org.eclipse.edc.plugins.autodoc.spi.ManifestRenderer;
+import org.eclipse.edc.runtime.metamodel.domain.ConfigurationSetting;
+import org.eclipse.edc.runtime.metamodel.domain.ModuleType;
+import org.eclipse.edc.runtime.metamodel.domain.Service;
+import org.eclipse.edc.runtime.metamodel.domain.ServiceReference;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static net.steppschuh.markdowngenerator.Markdown.bold;
+import static net.steppschuh.markdowngenerator.Markdown.code;
+import static net.steppschuh.markdowngenerator.Markdown.heading;
+import static net.steppschuh.markdowngenerator.Markdown.italic;
+import static net.steppschuh.markdowngenerator.Markdown.unorderedList;
+
+public class MarkdownManifestRenderer implements ManifestRenderer {
+
+    private static final String NEWLINE = System.lineSeparator();
+    private final OutputStream output;
+    private final StringBuilder stringBuilder;
+
+    public MarkdownManifestRenderer(OutputStream output) {
+        this.output = output;
+        stringBuilder = new StringBuilder();
+    }
+
+    @Override
+    public void handleDocumentHeader() {
+        stringBuilder.append(heading(DOCUMENT_HEADING, 1)).append(NEWLINE);
+        stringBuilder.append(NEWLINE);
+    }
+
+    @Override
+    public void handleModuleHeading(@Nullable String moduleName, @NotNull String modulePath, @NotNull String version) {
+        var name = ofNullable(moduleName).orElse(modulePath);
+
+        var moduleHeading = heading(format("Module `%s:%s`", name, version), 2);
+        stringBuilder.append(moduleHeading).append(NEWLINE);
+
+        if (moduleName != null) {
+            stringBuilder.append(italic(modulePath)).append(NEWLINE);
+        }
+        stringBuilder.append(NEWLINE);
+    }
+
+    @Override
+    public void handleModuleCategories(List<String> categories) {
+        // append categories as italic text
+        var cat = categories
+                .stream()
+                .filter(c -> c != null && !c.isEmpty())
+                .collect(Collectors.joining(","));
+
+        if (cat.isEmpty()) {
+            cat = NONE;
+        }
+
+        stringBuilder.append(italic(format("Categories: %s", cat))).append(NEWLINE);
+        stringBuilder.append(NEWLINE);
+    }
+
+    @Override
+    public void handleExtensionPoints(List<Service> extensionPoints) {
+        // append extension points
+        stringBuilder.append(heading(EXTENSION_POINTS, 3)).append(NEWLINE);
+        stringBuilder.append(listOrNone(unorderedList(extensionPoints.stream().map(s -> code(s.getService())).toList().toArray()))).append(NEWLINE);
+        stringBuilder.append(NEWLINE);
+    }
+
+    @Override
+    public void handleExtensionHeading() {
+        stringBuilder.append(heading(EXTENSIONS, 3)).append(NEWLINE);
+    }
+
+    @Override
+    public void handleExtensionHeader(@NotNull String className, String name, String overview, ModuleType type) {
+        stringBuilder.append(heading("Class: " + code(className), 4)).append(NEWLINE);
+
+        stringBuilder.append(bold("Name:")).append(format(" \"%s\"", name)).append(NEWLINE);
+        if (overview != null) {
+            stringBuilder.append(NEWLINE).append(bold("Overview:")).append(" ").append(overview).append(NEWLINE).append(NEWLINE);
+        }
+        stringBuilder.append(NEWLINE);
+    }
+
+    @Override
+    public void handleConfigurations(List<ConfigurationSetting> configuration) {
+        // add configuration table
+        var tableBuilder = new Table.Builder()
+                .addRow("Key", "Required", "Type", "Pattern", "Min", "Max", "Description");
+
+        configuration.forEach(setting -> tableBuilder.addRow(code(setting.getKey()),
+                setting.isRequired() ? code("*") : null,
+                code(setting.getType()),
+                ofNullable(setting.getPattern()).map(Markdown::code).orElse(null),
+                ofNullable(setting.getMinimum()).map(m -> code(String.valueOf(m))).orElse(null),
+                ofNullable(setting.getMaximum()).map(m -> code(String.valueOf(m))).orElse(null),
+                setting.getDescription()));
+
+        stringBuilder.append(heading("Configuration: ", 5));
+        if (!configuration.isEmpty()) {
+            stringBuilder.append(NEWLINE).append(NEWLINE).append(tableBuilder.build()).append(NEWLINE);
+        } else {
+            stringBuilder.append(italic(NONE)).append(NEWLINE);
+        }
+        stringBuilder.append(NEWLINE);
+    }
+
+    @Override
+    public void handleExposedServices(List<Service> provides) {
+        // add exposed services
+        stringBuilder.append(heading("Provided services:", 5)).append(NEWLINE);
+        stringBuilder.append(listOrNone(provides.stream().map(s -> code(s.getService())).toList().toArray())).append(NEWLINE);
+        stringBuilder.append(NEWLINE);
+    }
+
+    @Override
+    public void handleReferencedServices(List<ServiceReference> references) {
+        // add injected services
+        stringBuilder.append(heading("Referenced (injected) services:", 5)).append(NEWLINE);
+        stringBuilder.append(listOrNone(references.stream().map(s -> format("%s (%s)", code(s.getService()), s.isRequired() ? "required" : "optional")).toList().toArray())).append(NEWLINE);
+        stringBuilder.append(NEWLINE);
+    }
+
+    @Override
+    public OutputStream finalizeRendering() {
+        try {
+            output.write(stringBuilder.toString().getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new ManifestConverterException(e);
+        }
+        return output;
+    }
+
+    private MarkdownElement listOrNone(Object... items) {
+        if (items.length == 0 || Arrays.stream(items).allMatch(o -> o.toString().isEmpty())) {
+            return italic(NONE);
+        } else {
+            return unorderedList(items);
+        }
+    }
+}

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRenderer.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRenderer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Microsoft Corporation
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestConverterException.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestConverterException.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.autodoc.spi;
+
+public class ManifestConverterException extends RuntimeException {
+    public ManifestConverterException(Throwable e) {
+        super(e);
+    }
+}

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestConverterException.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestConverterException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Microsoft Corporation
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestReader.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestReader.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.autodoc.spi;
+
+import org.eclipse.edc.runtime.metamodel.domain.EdcModule;
+
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * Reads a manifest file, which contains a {@link List} of {@link EdcModule}. Implementations are file-format specific.
+ */
+public interface ManifestReader {
+    /**
+     * Reads an input stream, e.g. a FileInput stream, and interprets it
+     *
+     * @param inputStream The input
+     */
+    List<EdcModule> read(InputStream inputStream);
+}

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestReader.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestReader.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Microsoft Corporation
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestRenderer.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestRenderer.java
@@ -37,29 +37,29 @@ public interface ManifestRenderer {
     /**
      * Renders the document header
      */
-    void handleDocumentHeader();
+    void renderDocumentHeader();
 
     /**
      * Render the heading for a module.
      */
-    void handleModuleHeading(@Nullable String moduleName, @NotNull String modulePath, @NotNull String version);
+    void renderModuleHeading(@Nullable String moduleName, @NotNull String modulePath, @NotNull String version);
 
     /**
      * Render a document section for the categories of a module.
      *
      * @param categories May be empty, may contain empty strings.
      */
-    void handleModuleCategories(List<String> categories);
+    void renderCategories(List<String> categories);
 
     /**
      * Handles the creation of an {@link EdcServiceExtension} object, which usually represents all the services in a module, that are intended to be implemented or subclassed.
      */
-    void handleExtensionPoints(List<Service> extensionPoints);
+    void renderExtensionPoints(List<Service> extensionPoints);
 
     /**
      * Create a sub-heading for an extension
      */
-    void handleExtensionHeading();
+    void renderExtensionHeading();
 
     /**
      * Render the header for an extension.
@@ -69,22 +69,22 @@ public interface ManifestRenderer {
      * @param overview  A string containing more information about the extension. Can be null, empty or even multiline.
      * @param type      The type of extension module, it can either be an SPI module or an implementation module
      */
-    void handleExtensionHeader(@NotNull String className, @Nullable String name, @Nullable String overview, ModuleType type);
+    void renderExtensionHeader(@NotNull String className, @Nullable String name, @Nullable String overview, ModuleType type);
 
     /**
      * Render all configuration values that are declared by a particular extension
      */
-    void handleConfigurations(List<ConfigurationSetting> configuration);
+    void renderConfigurations(List<ConfigurationSetting> configuration);
 
     /**
      * Render all services, that are <em>provided</em> by a particular module.
      */
-    void handleExposedServices(List<Service> provides);
+    void renderExposedServices(List<Service> provides);
 
     /**
      * Render all services, that an extension <em>requires</em>, i.e. that must be provided by <em>other extensions</em>.
      */
-    void handleReferencedServices(List<ServiceReference> references);
+    void renderReferencedServices(List<ServiceReference> references);
 
     /**
      * Finalizes the conversion, e.g. by adding closing tags, adding footnotes, validation, etc.

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestRenderer.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestRenderer.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.autodoc.spi;
+
+import org.eclipse.edc.runtime.metamodel.domain.ConfigurationSetting;
+import org.eclipse.edc.runtime.metamodel.domain.EdcServiceExtension;
+import org.eclipse.edc.runtime.metamodel.domain.ModuleType;
+import org.eclipse.edc.runtime.metamodel.domain.Service;
+import org.eclipse.edc.runtime.metamodel.domain.ServiceReference;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.OutputStream;
+import java.util.List;
+
+/**
+ * The ManifestRenderer interface provides callback methods to render a manifest document.
+ */
+public interface ManifestRenderer {
+    String DOCUMENT_HEADING = "EDC Autodoc Manifest";
+    String EXTENSION_POINTS = "Extension points";
+    String EXTENSIONS = "Extensions";
+    String NONE = "None";
+
+    /**
+     * Renders the document header
+     */
+    void handleDocumentHeader();
+
+    /**
+     * Render the heading for a module.
+     */
+    void handleModuleHeading(@Nullable String moduleName, @NotNull String modulePath, @NotNull String version);
+
+    /**
+     * Render a document section for the categories of a module.
+     *
+     * @param categories May be empty, may contain empty strings.
+     */
+    void handleModuleCategories(List<String> categories);
+
+    /**
+     * Handles the creation of an {@link EdcServiceExtension} object, which usually represents all the services in a module, that are intended to be implemented or subclassed.
+     */
+    void handleExtensionPoints(List<Service> extensionPoints);
+
+    /**
+     * Create a sub-heading for an extension
+     */
+    void handleExtensionHeading();
+
+    /**
+     * Render the header for an extension.
+     *
+     * @param className The fully-qualified java classname.
+     * @param name      The human-readable extension name. May be null.
+     * @param overview  A string containing more information about the extension. Can be null, empty or even multiline.
+     * @param type      The type of extension module, it can either be an SPI module or an implementation module
+     */
+    void handleExtensionHeader(@NotNull String className, @Nullable String name, @Nullable String overview, ModuleType type);
+
+    /**
+     * Render all configuration values that are declared by a particular extension
+     */
+    void handleConfigurations(List<ConfigurationSetting> configuration);
+
+    /**
+     * Render all services, that are <em>provided</em> by a particular module.
+     */
+    void handleExposedServices(List<Service> provides);
+
+    /**
+     * Render all services, that an extension <em>requires</em>, i.e. that must be provided by <em>other extensions</em>.
+     */
+    void handleReferencedServices(List<ServiceReference> references);
+
+    /**
+     * Finalizes the conversion, e.g. by adding closing tags, adding footnotes, validation, etc.
+     *
+     * @return An {@link OutputStream} that contains the rendered document.
+     */
+    OutputStream finalizeRendering();
+}

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestRenderer.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestRenderer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Microsoft Corporation
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestWriter.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestWriter.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.autodoc.spi;
+
+import org.eclipse.edc.runtime.metamodel.domain.EdcModule;
+import org.eclipse.edc.runtime.metamodel.domain.EdcServiceExtension;
+
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Reads any input to a manifest, which is represented as {@link List} of {@link EdcModule}.
+ * All model objects are delegated down to implementors using callbacks.
+ */
+public class ManifestWriter {
+
+    private final ManifestRenderer renderer;
+
+    public ManifestWriter(ManifestRenderer renderer) {
+        this.renderer = renderer;
+    }
+
+    public OutputStream convert(List<EdcModule> input) {
+        beginConversion(input);
+        return renderer.finalizeRendering();
+    }
+
+    protected void beginConversion(List<EdcModule> input) {
+        renderer.handleDocumentHeader();
+        input.forEach(this::handleModule);
+    }
+
+
+    /**
+     * Delegates one top-level element, which are {@link EdcModule} objects.
+     * Do not override unless absolutely necessary!
+     *
+     * @param edcModule The module to render
+     */
+    protected void handleModule(EdcModule edcModule) {
+        renderer.handleModuleHeading(edcModule.getName(), edcModule.getModulePath(), edcModule.getVersion());
+
+        // append categories as italic text
+        renderer.handleModuleCategories(edcModule.getCategories());
+
+        // append extension points
+        renderer.handleExtensionPoints(edcModule.getExtensionPoints());
+
+        // append extensions
+        handleExtensions(edcModule.getExtensions());
+    }
+
+    protected void handleExtensions(Set<EdcServiceExtension> extensions) {
+        renderer.handleExtensionHeading();
+        extensions.forEach(this::handleServiceExtension);
+    }
+
+    protected void handleServiceExtension(EdcServiceExtension serviceExtension) {
+        renderer.handleExtensionHeader(serviceExtension.getClassName(), serviceExtension.getName(), serviceExtension.getOverview(), serviceExtension.getType());
+
+        // add configuration table
+        renderer.handleConfigurations(serviceExtension.getConfiguration());
+
+        // add exposed services
+        renderer.handleExposedServices(serviceExtension.getProvides());
+
+        // add injected services
+        renderer.handleReferencedServices(serviceExtension.getReferences());
+    }
+
+}

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestWriter.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestWriter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Microsoft Corporation
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestWriter.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestWriter.java
@@ -39,7 +39,7 @@ public class ManifestWriter {
     }
 
     protected void beginConversion(List<EdcModule> input) {
-        renderer.handleDocumentHeader();
+        renderer.renderDocumentHeader();
         input.forEach(this::handleModule);
     }
 
@@ -51,34 +51,34 @@ public class ManifestWriter {
      * @param edcModule The module to render
      */
     protected void handleModule(EdcModule edcModule) {
-        renderer.handleModuleHeading(edcModule.getName(), edcModule.getModulePath(), edcModule.getVersion());
+        renderer.renderModuleHeading(edcModule.getName(), edcModule.getModulePath(), edcModule.getVersion());
 
         // append categories as italic text
-        renderer.handleModuleCategories(edcModule.getCategories());
+        renderer.renderCategories(edcModule.getCategories());
 
         // append extension points
-        renderer.handleExtensionPoints(edcModule.getExtensionPoints());
+        renderer.renderExtensionPoints(edcModule.getExtensionPoints());
 
         // append extensions
         handleExtensions(edcModule.getExtensions());
     }
 
     protected void handleExtensions(Set<EdcServiceExtension> extensions) {
-        renderer.handleExtensionHeading();
+        renderer.renderExtensionHeading();
         extensions.forEach(this::handleServiceExtension);
     }
 
     protected void handleServiceExtension(EdcServiceExtension serviceExtension) {
-        renderer.handleExtensionHeader(serviceExtension.getClassName(), serviceExtension.getName(), serviceExtension.getOverview(), serviceExtension.getType());
+        renderer.renderExtensionHeader(serviceExtension.getClassName(), serviceExtension.getName(), serviceExtension.getOverview(), serviceExtension.getType());
 
         // add configuration table
-        renderer.handleConfigurations(serviceExtension.getConfiguration());
+        renderer.renderConfigurations(serviceExtension.getConfiguration());
 
         // add exposed services
-        renderer.handleExposedServices(serviceExtension.getProvides());
+        renderer.renderExposedServices(serviceExtension.getProvides());
 
         // add injected services
-        renderer.handleReferencedServices(serviceExtension.getReferences());
+        renderer.renderReferencedServices(serviceExtension.getReferences());
     }
 
 }

--- a/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/json/JsonManifestReaderTest.java
+++ b/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/json/JsonManifestReaderTest.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.autodoc.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.plugins.autodoc.spi.ManifestConverterException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JsonManifestReaderTest {
+
+    private final JsonManifestReader reader = new JsonManifestReader(new ObjectMapper());
+
+    @BeforeEach
+    void setUp() {
+
+    }
+
+    @Test
+    void read() {
+        var list = reader.read(readResource("example_manifest.json"));
+        assertThat(list)
+                .isNotNull()
+                .hasSize(96);
+    }
+
+    @Test
+    void read_inputNotJson() {
+        assertThatThrownBy(() -> reader.read(readResource("invalid_manifest.json")))
+                .isInstanceOf(ManifestConverterException.class)
+                .hasRootCauseInstanceOf(JsonProcessingException.class);
+    }
+
+    private InputStream readResource(String filename) {
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream(filename);
+    }
+}

--- a/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRendererTest.java
+++ b/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRendererTest.java
@@ -47,7 +47,6 @@ class MarkdownManifestRendererTest {
         assertThat(result).isNotNull();
         assertThat(os).isEqualTo(testOutputStream);
 
-        System.out.println(result);
     }
 
     @Test
@@ -59,7 +58,21 @@ class MarkdownManifestRendererTest {
         assertThat(result).isNotNull();
         assertThat(os).isEqualTo(testOutputStream);
 
-        System.out.println(result);
+    }
+
+    @Test
+    void convert_emptyObject() {
+        var list = List.of(EdcModule.Builder.newInstance().modulePath("foo").version("0.1.0-bar").build());
+        var os = writer.convert(list);
+
+        var result = testOutputStream.toString();
+        assertThat(result).isNotNull();
+        assertThat(os).isEqualTo(testOutputStream);
+
+        assertThat(result).contains("Module `foo:0.1.0-bar`");
+        assertThat(result).contains("### Extension points");
+        assertThat(result).contains("### Extensions");
+        assertThat(result).doesNotContain("Configuration:");
     }
 
     private List<EdcModule> generateManifest(String filename) {

--- a/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRendererTest.java
+++ b/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRendererTest.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.autodoc.markdown;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.plugins.autodoc.spi.ManifestWriter;
+import org.eclipse.edc.runtime.metamodel.domain.EdcModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MarkdownManifestRendererTest {
+
+    private ManifestWriter writer;
+    private ByteArrayOutputStream testOutputStream;
+
+    @BeforeEach
+    void setUp() {
+        testOutputStream = new ByteArrayOutputStream();
+        writer = new ManifestWriter(new MarkdownManifestRenderer(testOutputStream));
+    }
+
+    @Test
+    void convert_exampleJson() {
+        var list = generateManifest("example_manifest.json");
+        var os = writer.convert(list);
+
+        var result = testOutputStream.toString();
+        assertThat(result).isNotNull();
+        assertThat(os).isEqualTo(testOutputStream);
+
+        System.out.println(result);
+    }
+
+    @Test
+    void convert_simpleJson() {
+        var list = generateManifest("simple_manifest.json");
+        var os = writer.convert(list);
+
+        var result = testOutputStream.toString();
+        assertThat(result).isNotNull();
+        assertThat(os).isEqualTo(testOutputStream);
+
+        System.out.println(result);
+    }
+
+    private List<EdcModule> generateManifest(String filename) {
+        try {
+            return new ObjectMapper().readValue(Thread.currentThread().getContextClassLoader().getResourceAsStream(filename), new TypeReference<>() {
+            });
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRendererTest.java
+++ b/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRendererTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Microsoft Corporation
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 

--- a/plugins/autodoc/autodoc-converters/src/test/resources/example_manifest.json
+++ b/plugins/autodoc/autodoc-converters/src/test/resources/example_manifest.json
@@ -1,0 +1,4677 @@
+[
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager"
+          },
+          {
+            "service": "java.time.Clock"
+          },
+          {
+            "service": "org.eclipse.edc.spi.telemetry.Telemetry"
+          }
+        ],
+        "references": [],
+        "configuration": [],
+        "name": "Boot Services",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.boot.BootServicesExtension"
+      }
+    ],
+    "extensionPoints": [
+    ],
+    "modulePath": "org.eclipse.edc:boot",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.spi.system.Hostname"
+          },
+          {
+            "service": "org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.spi.command.CommandHandlerRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.spi.agent.ParticipantAgentService"
+          },
+          {
+            "service": "org.eclipse.edc.policy.engine.spi.RuleBindingRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.policy.engine.spi.PolicyEngine"
+          },
+          {
+            "service": "org.eclipse.edc.spi.event.EventRouter"
+          },
+          {
+            "service": "org.eclipse.edc.spi.system.health.HealthCheckService"
+          },
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.system.ExecutorInstrumentation",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.PrivateKeyResolver",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.core.event.EventExecutorServiceContainer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.core.system.health.check.liveness-period",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.core.system.health.check.startup-period",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.core.system.health.check.readiness-period",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.core.system.health.check.threadpool-size",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.hostname",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.agent.identity.key",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "Core Services",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.core.CoreServicesExtension"
+      },
+      {
+        "categories": [],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext"
+          },
+          {
+            "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.spi.system.ExecutorInstrumentation"
+          },
+          {
+            "service": "org.eclipse.edc.connector.core.event.EventExecutorServiceContainer"
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.Vault"
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.PrivateKeyResolver"
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.CertificateResolver"
+          },
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient"
+          },
+          {
+            "service": "okhttp3.OkHttpClient"
+          },
+          {
+            "service": "dev.failsafe.RetryPolicy<T>"
+          }
+        ],
+        "references": [
+          {
+            "service": "okhttp3.EventListener",
+            "required": false
+          }
+        ],
+        "configuration": [],
+        "name": "CoreDefaultServicesExtension",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.core.CoreDefaultServicesExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:connector-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      "",
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.catalog.spi.DataServiceRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.catalog.spi.DistributionResolver"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Catalog Default Services",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.catalog.CatalogDefaultServicesExtension"
+      },
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.catalog.spi.DatasetResolver"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.asset.AssetIndex",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.catalog.spi.DistributionResolver",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.query.CriterionToAssetPredicateConverter",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Catalog Core",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.catalog.CatalogCoreExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:catalog-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      "",
+      "",
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.command.CommandHandlerRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Contract Negotiation command handlers",
+        "type": "extension",
+        "overview": " Contract Negotiation Default Services Extension\n",
+        "className": "org.eclipse.edc.connector.contract.ContractNegotiationCommandExtension"
+      },
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.validation.ContractValidationService"
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegotiationManager"
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.ProviderContractNegotiationManager"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.asset.AssetIndex",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.agent.ParticipantAgentService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.policy.engine.spi.PolicyEngine",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.monitor.Monitor",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.telemetry.Telemetry",
+            "required": true
+          },
+          {
+            "service": "java.time.Clock",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.event.EventRouter",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.policy.engine.spi.RuleBindingRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.protocol.ProtocolWebhook",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegotiationObservable",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.ContractNegotiationPendingGuard",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.system.ExecutorInstrumentation",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.negotiation.state-machine.iteration-wait-millis",
+            "required": false,
+            "type": "long",
+            "description": "the iteration wait time in milliseconds in the negotiation state machine. Default value 1000"
+          },
+          {
+            "key": "edc.negotiation.consumer.state-machine.batch-size",
+            "required": false,
+            "type": "int",
+            "description": "the batch size in the consumer negotiation state machine. Default value 20"
+          },
+          {
+            "key": "edc.negotiation.provider.state-machine.batch-size",
+            "required": false,
+            "type": "int",
+            "description": "the batch size in the provider negotiation state machine. Default value 20"
+          },
+          {
+            "key": "edc.negotiation.consumer.send.retry.limit",
+            "required": false,
+            "type": "int",
+            "description": "how many times a specific operation must be tried before terminating the consumer negotiation with error"
+          },
+          {
+            "key": "edc.negotiation.provider.send.retry.limit",
+            "required": false,
+            "type": "int",
+            "description": "how many times a specific operation must be tried before terminating the provider negotiation with error"
+          },
+          {
+            "key": "edc.negotiation.consumer.send.retry.base-delay.ms",
+            "required": false,
+            "type": "long",
+            "description": "The base delay for the consumer negotiation retry mechanism in millisecond"
+          },
+          {
+            "key": "edc.negotiation.provider.send.retry.base-delay.ms",
+            "required": false,
+            "type": "long",
+            "description": "The base delay for the provider negotiation retry mechanism in millisecond"
+          }
+        ],
+        "name": "Contract Core",
+        "type": "extension",
+        "overview": " Contract Negotiation Default Services Extension\n",
+        "className": "org.eclipse.edc.connector.contract.ContractCoreExtension"
+      },
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver"
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegotiationObservable"
+          },
+          {
+            "service": "org.eclipse.edc.connector.policy.spi.store.PolicyArchive"
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.ContractNegotiationPendingGuard"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.policy.engine.spi.PolicyEngine",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Contract Negotiation Default Services",
+        "type": "extension",
+        "overview": " Contract Negotiation Default Services Extension\n",
+        "className": "org.eclipse.edc.connector.contract.ContractNegotiationDefaultServicesExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:contract-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.spi.asset.AssetService"
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.catalog.CatalogService"
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.catalog.CatalogProtocolService"
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService"
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.contractdefinition.ContractDefinitionService"
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService"
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService"
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.policydefinition.PolicyDefinitionService"
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.transferprocess.TransferProcessService"
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.transferprocess.TransferProcessProtocolService"
+          }
+        ],
+        "references": [
+          {
+            "service": "java.time.Clock",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.monitor.Monitor",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.event.EventRouter",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.asset.AssetIndex",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegotiationManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.TransferProcessManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.validation.ContractValidationService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegotiationObservable",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.observe.TransferProcessObservable",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.telemetry.Telemetry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.agent.ParticipantAgentService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.catalog.spi.DataServiceRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.catalog.spi.DatasetResolver",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.command.CommandHandlerRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Control Plane Services",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.service.ControlPlaneServicesExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:control-plane-aggregate-services",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.spi.asset.AssetIndex"
+          },
+          {
+            "service": "org.eclipse.edc.spi.asset.DataAddressResolver"
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore"
+          },
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore"
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore"
+          },
+          {
+            "service": "org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore"
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.callback.CallbackRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.spi.query.CriterionToAssetPredicateConverter"
+          }
+        ],
+        "references": [],
+        "configuration": [],
+        "name": "Control Plane Default Services",
+        "type": "extension",
+        "overview": " Provides default service implementations for fallback\n",
+        "className": "org.eclipse.edc.connector.ControlPlaneDefaultServicesExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:control-plane-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      "",
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "TransferProcessCommandExtension",
+        "type": "extension",
+        "overview": " Provides core data transfer services to the system.\n",
+        "className": "org.eclipse.edc.connector.transfer.TransferProcessCommandExtension"
+      },
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.TransferProcessManager"
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceReceiverRegistry"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.status.StatusCheckerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.observe.TransferProcessObservable",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.policy.spi.store.PolicyArchive",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.command.CommandHandlerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.asset.DataAddressResolver",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.Vault",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.event.EventRouter",
+            "required": true
+          },
+          {
+            "service": "java.time.Clock",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.telemetry.Telemetry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.protocol.ProtocolWebhook",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.TransferProcessPendingGuard",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.transfer.state-machine.iteration-wait-millis",
+            "required": false,
+            "type": "long",
+            "description": "the iteration wait time in milliseconds in the transfer process state machine. Default value 1000"
+          },
+          {
+            "key": "edc.transfer.state-machine.batch-size",
+            "required": false,
+            "type": "int",
+            "description": "the batch size in the transfer process state machine. Default value 20"
+          },
+          {
+            "key": "edc.transfer.send.retry.limit",
+            "required": false,
+            "type": "int",
+            "description": "how many times a specific operation must be tried before terminating the transfer with error"
+          },
+          {
+            "key": "edc.transfer.send.retry.base-delay.ms",
+            "required": false,
+            "type": "long",
+            "description": "The base delay for the transfer retry mechanism in millisecond"
+          }
+        ],
+        "name": "Transfer Core",
+        "type": "extension",
+        "overview": " Provides core data transfer services to the system.\n",
+        "className": "org.eclipse.edc.connector.transfer.TransferCoreExtension"
+      },
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager"
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator"
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.status.StatusCheckerRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager"
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.observe.TransferProcessObservable"
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.TransferProcessPendingGuard"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.policy.engine.spi.PolicyEngine",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Transfer Process Default Services",
+        "type": "extension",
+        "overview": " Provides core data transfer services to the system.\n",
+        "className": "org.eclipse.edc.connector.transfer.TransferProcessDefaultServicesExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:transfer-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      "",
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager"
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService"
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.pipeline.DataTransferExecutorServiceContainer"
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.registry.TransferServiceRegistry"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.framework.registry.TransferServiceSelectionStrategy",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.client.spi.transferprocess.TransferProcessApiClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.system.ExecutorInstrumentation",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.telemetry.Telemetry",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.dataplane.queue.capacity",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.dataplane.workers",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.dataplane.wait",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.dataplane.transfer.threads",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "Data Plane Framework",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.dataplane.framework.DataPlaneFrameworkExtension"
+      },
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.api.client.spi.transferprocess.TransferProcessApiClient"
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.framework.registry.TransferServiceSelectionStrategy"
+          }
+        ],
+        "references": [],
+        "configuration": [],
+        "name": "Data Plane Framework Default Services",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.dataplane.framework.DataPlaneDefaultServicesExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:data-plane-framework",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore"
+          }
+        ],
+        "references": [],
+        "configuration": [],
+        "name": "DataPlaneSelectorDefaultServicesExtension",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.dataplane.selector.core.DataPlaneSelectorDefaultServicesExtension"
+      },
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelector"
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.spi.strategy.SelectionStrategyRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "DataPlane core selector",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.dataplane.selector.core.DataPlaneSelectorExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:data-plane-selector-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpRemoteMessageDispatcher"
+          },
+          {
+            "service": "org.eclipse.edc.protocol.dsp.spi.serialization.JsonLdRemoteMessageSerializer"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.iam.IdentityService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.jsonld.spi.JsonLd",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.iam.TokenDecorator",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.policy.engine.spi.PolicyEngine",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Dataspace Protocol Core Extension",
+        "type": "extension",
+        "overview": " Provides an implementation of {@link DspHttpRemoteMessageDispatcher} to support sending dataspace\n protocol messages. The dispatcher can then be used by other extensions to add support for\n specific message types.\n",
+        "className": "org.eclipse.edc.protocol.dsp.DspHttpCoreExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:dsp-http-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.protocol.dsp.api.configuration.DspApiConfiguration"
+          },
+          {
+            "service": "org.eclipse.edc.spi.protocol.ProtocolWebhook"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.WebServer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.configuration.WebServiceConfigurer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.jsonld.spi.JsonLd",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Dataspace Protocol API Configuration Extension",
+        "type": "extension",
+        "overview": " Provides the configuration for the Dataspace Protocol API context. Creates the API context\n using {@link #DEFAULT_PROTOCOL_PORT} and {@link #DEFAULT_PROTOCOL_API_PATH}, if no respective\n settings are provided. Configures the API context to allow Jakarta JSON-API types as endpoint\n parameters.\n",
+        "className": "org.eclipse.edc.protocol.dsp.api.configuration.DspApiConfigurationExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:dsp-api-configuration",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.jsonld.spi.JsonLd"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.jsonld.http.enabled",
+            "required": false,
+            "type": "boolean",
+            "description": "If set enable http json-ld document resolution"
+          },
+          {
+            "key": "edc.jsonld.https.enabled",
+            "required": false,
+            "type": "boolean",
+            "description": "If set enable https json-ld document resolution"
+          }
+        ],
+        "name": "JSON-LD Extension",
+        "type": "extension",
+        "overview": " Adds support for working with JSON-LD. Provides an ObjectMapper that works with Jakarta JSON-P\n types through the TypeManager context {@link CoreConstants#JSON_LD} and a registry\n for {@link JsonLdTransformer}s. The module also offers\n functions for working with JSON-LD structures.\n",
+        "className": "org.eclipse.edc.jsonld.JsonLdExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:json-ld",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebServer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.configuration.WebServiceConfigurer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.control.configuration.ControlApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.dataplane.token.validation.endpoint",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "Data Plane API",
+        "type": "extension",
+        "overview": " This extension provides the Data Plane API:\n - Control API: set of endpoints to trigger/monitor/cancel data transfers that should be accessible only from the Control Plane.\n - Public API: generic endpoint open to other participants of the Dataspace and used to proxy a data request to the actual data source.\n",
+        "className": "org.eclipse.edc.connector.dataplane.api.DataPlaneApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:data-plane-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.client.DataPlaneClient"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneSelectorClient",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.dataplane.client.selector.strategy",
+            "required": false,
+            "type": "string",
+            "description": "Defines strategy for Data Plane instance selection in case Data Plane is not embedded in current runtime"
+          }
+        ],
+        "name": "Data Plane Client",
+        "type": "extension",
+        "overview": " This extension provides the Data Plane API:\n - Control API: set of endpoints to trigger/monitor/cancel data transfers that should be accessible only from the Control Plane.\n - Public API: generic endpoint open to other participants of the Dataspace and used to proxy a data request to the actual data source.\n",
+        "className": "org.eclipse.edc.connector.dataplane.client.DataPlaneClientExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:data-plane-client",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParamsProvider"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.pipeline.DataTransferExecutorServiceContainer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.Vault",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.dataplane.http.sink.partition.size",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "Data Plane HTTP",
+        "type": "extension",
+        "overview": " Provides support for reading data from an HTTP endpoint and sending data to an HTTP endpoint.\n",
+        "className": "org.eclipse.edc.connector.dataplane.http.DataPlaneHttpExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:data-plane-http",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "java.time.Clock",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParamsProvider",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.Vault",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.PrivateKeyResolver",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Data Plane HTTP OAuth2",
+        "type": "extension",
+        "overview": " Provides support for adding OAuth2 authentication to http data transfer\n",
+        "className": "org.eclipse.edc.connector.dataplane.http.oauth2.DataPlaneHttpOauth2Extension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:data-plane-http-oauth2-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.pipeline.DataTransferExecutorServiceContainer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService",
+            "required": true
+          },
+          {
+            "service": "java.time.Clock",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Data Plane Kafka",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.dataplane.kafka.DataPlaneKafkaExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:data-plane-kafka",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.transform.ManagementApiTypeTransformerRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "DataPlane selector API",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.dataplane.selector.DataPlaneSelectorApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:data-plane-selector-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneSelectorClient"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.dpf.selector.url",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "DataPlane instance client",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.dataplane.selector.DataPlaneInstanceClientExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:data-plane-selector-client",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.api.auth.spi.AuthenticationService"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:auth-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "Auth services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.spi.monitor.Monitor"
+      },
+      {
+        "service": "org.eclipse.edc.spi.asset.AssetIndex"
+      },
+      {
+        "service": "org.eclipse.edc.spi.asset.DataAddressResolver"
+      },
+      {
+        "service": "org.eclipse.edc.spi.security.CertificateResolver"
+      },
+      {
+        "service": "org.eclipse.edc.spi.security.PrivateKeyResolver"
+      },
+      {
+        "service": "org.eclipse.edc.spi.security.Vault"
+      },
+      {
+        "service": "org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry"
+      },
+      {
+        "service": "org.eclipse.edc.spi.system.health.HealthCheckService"
+      },
+      {
+        "service": "org.eclipse.edc.spi.system.ExecutorInstrumentation"
+      },
+      {
+        "service": "org.eclipse.edc.spi.iam.PublicKeyResolver"
+      },
+      {
+        "service": "org.eclipse.edc.spi.iam.IdentityService"
+      },
+      {
+        "service": "org.eclipse.edc.spi.command.CommandHandlerRegistry"
+      },
+      {
+        "service": "org.eclipse.edc.spi.event.EventRouter"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:core-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "Core services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry"
+      },
+      {
+        "service": "org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver"
+      },
+      {
+        "service": "org.eclipse.edc.iam.did.spi.store.DidStore"
+      },
+      {
+        "service": "org.eclipse.edc.iam.did.spi.credentials.CredentialsVerifier"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:identity-did-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "IAM DID services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:jwt-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "JTW services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.iam.oauth2.spi.Oauth2ValidationRulesRegistry"
+      },
+      {
+        "service": "org.eclipse.edc.iam.oauth2.spi.Oauth2JwtDecoratorRegistry"
+      },
+      {
+        "service": "org.eclipse.edc.iam.oauth2.spi.CredentialsRequestAdditionalParametersProvider"
+      },
+      {
+        "service": "org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:oauth2-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "OAuth2 services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.policy.engine.spi.PolicyEngine"
+      },
+      {
+        "service": "org.eclipse.edc.policy.engine.spi.RuleBindingRegistry"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:policy-engine-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "Policy Engine services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:transaction-datasource-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "DataSource services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.transaction.spi.TransactionContext"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:transaction-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "Transactional context services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.web.spi.configuration.WebServiceConfigurer"
+      },
+      {
+        "service": "org.eclipse.edc.web.spi.WebServer"
+      },
+      {
+        "service": "org.eclipse.edc.web.spi.WebService"
+      },
+      {
+        "service": "org.eclipse.edc.web.spi.validation.InterceptorFunctionRegistry"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:web-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "Web services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.connector.contract.spi.offer.ContractDefinitionResolver"
+      },
+      {
+        "service": "org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore"
+      },
+      {
+        "service": "org.eclipse.edc.connector.contract.spi.negotiation.NegotiationWaitStrategy"
+      },
+      {
+        "service": "org.eclipse.edc.connector.contract.spi.negotiation.observe.ContractNegotiationObservable"
+      },
+      {
+        "service": "org.eclipse.edc.connector.contract.spi.negotiation.ProviderContractNegotiationManager"
+      },
+      {
+        "service": "org.eclipse.edc.connector.contract.spi.negotiation.ConsumerContractNegotiationManager"
+      },
+      {
+        "service": "org.eclipse.edc.connector.contract.spi.negotiation.ContractNegotiationPendingGuard"
+      },
+      {
+        "service": "org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore"
+      },
+      {
+        "service": "org.eclipse.edc.connector.contract.spi.validation.ContractValidationService"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:contract-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "Contract services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.connector.api.client.spi.transferprocess.TransferProcessApiClient"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:control-plane-api-client-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "Control Plane API Services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.connector.policy.spi.store.PolicyArchive"
+      },
+      {
+        "service": "org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:policy-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "Policy services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.connector.transfer.dataplane.spi.security.DataEncrypter"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:transfer-data-plane-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "Transfer data plane services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager"
+      },
+      {
+        "service": "org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator"
+      },
+      {
+        "service": "org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceReceiverRegistry"
+      },
+      {
+        "service": "org.eclipse.edc.connector.transfer.spi.TransferProcessPendingGuard"
+      },
+      {
+        "service": "org.eclipse.edc.connector.transfer.spi.status.StatusCheckerRegistry"
+      },
+      {
+        "service": "org.eclipse.edc.connector.transfer.spi.observe.TransferProcessObservable"
+      },
+      {
+        "service": "org.eclipse.edc.connector.transfer.spi.TransferProcessManager"
+      },
+      {
+        "service": "org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore"
+      },
+      {
+        "service": "org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:transfer-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "Transfer services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService"
+      },
+      {
+        "service": "org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager"
+      },
+      {
+        "service": "org.eclipse.edc.connector.dataplane.spi.registry.TransferServiceRegistry"
+      },
+      {
+        "service": "org.eclipse.edc.connector.dataplane.spi.client.DataPlaneClient"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:data-plane-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "DataPlane services"
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService"
+      },
+      {
+        "service": "org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneSelectorClient"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:data-plane-selector-spi",
+    "version": "0.2.1-SNAPSHOT",
+    "name": "DataPlane selector services"
+  },
+  {
+    "categories": [],
+    "extensions": [
+      {
+        "categories": [],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "BackendServiceTestExtension",
+        "type": "extension",
+        "overview": null,
+        "className": "org.eclipse.edc.test.e2e.BackendServiceTestExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:backend-service",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.iam.IdentityService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.protocol.dsp.api.configuration.DspApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.catalog.CatalogProtocolService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.catalog.spi.DataServiceRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Dataspace Protocol Catalog Extension",
+        "type": "extension",
+        "overview": " Creates and registers the controller for dataspace protocol catalog requests.\n",
+        "className": "org.eclipse.edc.protocol.dsp.catalog.api.DspCatalogApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:dsp-catalog-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpRemoteMessageDispatcher",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.protocol.dsp.spi.serialization.JsonLdRemoteMessageSerializer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.jsonld.spi.JsonLd",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Dataspace Protocol Catalog HTTP Dispatcher Extension",
+        "type": "extension",
+        "overview": " Creates and registers the HTTP dispatcher delegate for sending a catalog request as defined in\n the dataspace protocol specification.\n",
+        "className": "org.eclipse.edc.protocol.dsp.catalog.dispatcher.DspCatalogHttpDispatcherExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:dsp-catalog-http-dispatcher",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Dataspace Protocol Catalog Transform Extension",
+        "type": "extension",
+        "overview": " Provides the transformers for catalog message types via the {@link TypeTransformerRegistry}.\n",
+        "className": "org.eclipse.edc.protocol.dsp.catalog.transform.DspCatalogTransformExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:dsp-catalog-transform",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.iam.IdentityService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.protocol.dsp.api.configuration.DspApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.monitor.Monitor",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationProtocolService",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Dataspace Protocol Negotiation Api Extension",
+        "type": "extension",
+        "overview": " Creates and registers the controller for dataspace protocol negotiation requests.\n",
+        "className": "org.eclipse.edc.protocol.dsp.negotiation.api.DspNegotiationApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:dsp-negotiation-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpRemoteMessageDispatcher",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.protocol.dsp.spi.serialization.JsonLdRemoteMessageSerializer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.jsonld.spi.JsonLd",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Dataspace Protocol Negotiation HTTP Dispatcher Extension",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.protocol.dsp.negotiation.dispatcher.DspNegotiationHttpDispatcherExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:dsp-negotiation-http-dispatcher",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Dataspace Protocol Negotiation Transform Extension",
+        "type": "extension",
+        "overview": " Provides the transformers for negotiation message types via the {@link TypeTransformerRegistry}.\n",
+        "className": "org.eclipse.edc.protocol.dsp.negotiation.transform.DspNegotiationTransformExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:dsp-negotiation-transform",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.protocol.dsp.api.configuration.DspApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.monitor.Monitor",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.transferprocess.TransferProcessProtocolService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.iam.IdentityService",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Dataspace Protocol: TransferProcess API Extension",
+        "type": "extension",
+        "overview": " Creates and registers the controller for dataspace protocol transfer process requests.\n",
+        "className": "org.eclipse.edc.protocol.dsp.transferprocess.api.DspTransferProcessApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:dsp-transfer-process-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.protocol.dsp.spi.dispatcher.DspHttpRemoteMessageDispatcher",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.protocol.dsp.spi.serialization.JsonLdRemoteMessageSerializer",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Dataspace Protocol Transfer HTTP Dispatcher Extension",
+        "type": "extension",
+        "overview": " Provides HTTP dispatching for Dataspace Protocol transfer process messages via the {@link DspHttpRemoteMessageDispatcher}.\n",
+        "className": "org.eclipse.edc.protocol.dsp.transferprocess.dispatcher.DspTransferProcessDispatcherExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:dsp-transfer-process-http-dispatcher",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Dataspace Protocol Transfer Process Transform Extension",
+        "type": "extension",
+        "overview": " Provides the transformers for transferprocess message types via the {@link TypeTransformerRegistry}.\n",
+        "className": "org.eclipse.edc.protocol.dsp.transferprocess.transformer.DspTransferProcessTransformExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:dsp-transfer-process-transform",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.api.auth.spi.AuthenticationService"
+          }
+        ],
+        "references": [],
+        "configuration": [],
+        "name": "ApiCoreDefaultServicesExtension",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.api.ApiCoreDefaultServicesExtension"
+      },
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "API Core",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.api.ApiCoreExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:api-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.system.health.HealthCheckService",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Observability API",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.api.observability.ObservabilityApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:api-observability",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.api.control.configuration.ControlApiConfiguration"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebServer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.configuration.WebServiceConfigurer",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Control API configuration",
+        "type": "extension",
+        "overview": " Tells all the Control API controllers under which context alias they need to register their resources: either\n `default` or `control`\n",
+        "className": "org.eclipse.edc.connector.api.control.configuration.ControlApiConfigurationExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:control-api-configuration",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration"
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.transform.ManagementApiTypeTransformerRegistry"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.WebServer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.api.auth.spi.AuthenticationService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.configuration.WebServiceConfigurer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.jsonld.spi.JsonLd",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Management API configuration",
+        "type": "extension",
+        "overview": " Tells all the Management API controllers under which context alias they need to register their resources: either `default` or `management`\n",
+        "className": "org.eclipse.edc.connector.api.management.configuration.ManagementApiConfigurationExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:management-api-configuration",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.api.auth.spi.AuthenticationService"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.security.Vault",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.api.auth.basic.vault-keys",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "Basic authentication",
+        "type": "extension",
+        "overview": " Extension that registers an AuthenticationService that uses API Keys\n",
+        "className": "org.eclipse.edc.api.auth.basic.BasicAuthenticationExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:auth-basic",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.api.auth.spi.AuthenticationService"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.security.Vault",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.api.auth.key",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.api.auth.key.alias",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "Static token API Authentication",
+        "type": "extension",
+        "overview": " Extension that registers an AuthenticationService that uses API Keys\n",
+        "className": "org.eclipse.edc.api.auth.token.TokenBasedAuthenticationExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:auth-tokenbased",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [],
+        "configuration": [
+          {
+            "key": "edc.fs.config",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "FS Configuration",
+        "type": "extension",
+        "overview": " Sources configuration values from a properties file.\n",
+        "className": "org.eclipse.edc.configuration.filesystem.FsConfigurationExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:configuration-filesystem",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.event.EventRouter",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "java.time.Clock",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.system.Hostname",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.events.cloudevents.endpoint",
+            "required": true,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "Cloud events HTTP",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.event.cloud.http.CloudEventsHttpExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:events-cloud-http",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [],
+    "extensions": [
+      {
+        "categories": [],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService"
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.validation.InterceptorFunctionRegistry"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.jetty.JettyService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "JerseyExtension",
+        "type": "extension",
+        "overview": null,
+        "className": "org.eclipse.edc.web.jersey.JerseyExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:jersey-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [],
+    "extensions": [
+      {
+        "categories": [],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "io.micrometer.core.instrument.MeterRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.metrics.enabled",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.metrics.jersey.enabled",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "JerseyMicrometerExtension",
+        "type": "extension",
+        "overview": null,
+        "className": "org.eclipse.edc.web.jersey.micrometer.JerseyMicrometerExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:jersey-micrometer",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [],
+    "extensions": [
+      {
+        "categories": [],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebServer"
+          },
+          {
+            "service": "org.eclipse.edc.web.jetty.JettyService"
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.configuration.WebServiceConfigurer"
+          }
+        ],
+        "references": [],
+        "configuration": [
+          {
+            "key": "edc.web.https.keystore.password",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.web.https.keymanager.password",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.web.https.keystore.path",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.web.https.keystore.type",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "JettyExtension",
+        "type": "extension",
+        "overview": null,
+        "className": "org.eclipse.edc.web.jetty.JettyExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:jetty-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.jetty.JettyService",
+            "required": true
+          },
+          {
+            "service": "io.micrometer.core.instrument.MeterRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.metrics.enabled",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.metrics.jetty.enabled",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "Jetty Micrometer Metrics",
+        "type": "extension",
+        "overview": " An extension that registers Micrometer {@link JettyConnectionMetrics} into Jetty to\n provide server metrics.\n",
+        "className": "org.eclipse.edc.web.jetty.micrometer.JettyMicrometerExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:jetty-micrometer",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.spi.iam.IdentityService"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Mock IAM",
+        "type": "extension",
+        "overview": " An IAM provider mock used for testing.\n",
+        "className": "org.eclipse.edc.iam.mock.IamMockExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:iam-mock",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "okhttp3.EventListener"
+          },
+          {
+            "service": "org.eclipse.edc.spi.system.ExecutorInstrumentation"
+          },
+          {
+            "service": "io.micrometer.core.instrument.MeterRegistry"
+          }
+        ],
+        "references": [],
+        "configuration": [
+          {
+            "key": "edc.metrics.enabled",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.metrics.system.enabled",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.metrics.okhttp.enabled",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.metrics.executor.enabled",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "Micrometer Metrics",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.metrics.micrometer.MicrometerExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:micrometer-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [],
+        "configuration": [],
+        "name": "Logger monitor",
+        "type": "extension",
+        "overview": " Extension adding logging monitor.\n",
+        "className": "org.eclipse.edc.monitor.logger.LoggerMonitorExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:monitor-jdk-logger",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.sql.QueryExecutor"
+          }
+        ],
+        "references": [],
+        "configuration": [],
+        "name": "SQL Core",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.sql.SqlCoreExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:sql-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext"
+          },
+          {
+            "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry"
+          }
+        ],
+        "references": [],
+        "configuration": [],
+        "name": "Atomikos Transaction",
+        "type": "extension",
+        "overview": " Provides an implementation of a {@link DataSourceRegistry} and a {@link TransactionContext} backed by Atomikos.\n",
+        "className": "org.eclipse.edc.transaction.atomikos.AtomikosTransactionExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:transaction-atomikos",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext"
+          }
+        ],
+        "references": [],
+        "configuration": [],
+        "name": "Local Transaction",
+        "type": "extension",
+        "overview": " Support for transaction context backed by one or more local resources, including a {@link DataSourceRegistry}.\n",
+        "className": "org.eclipse.edc.transaction.local.LocalTransactionExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:transaction-local",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.spi.security.PrivateKeyResolver"
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.CertificateResolver"
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.Vault"
+          }
+        ],
+        "references": [],
+        "configuration": [],
+        "name": "FS Vault",
+        "type": "extension",
+        "overview": " Bootstraps the file system-based vault extension.\n",
+        "className": "org.eclipse.edc.vault.filesystem.FsVaultExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:vault-filesystem",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.system.health.HealthCheckService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.vault.hashicorp.health.check.enabled",
+            "required": false,
+            "type": "boolean",
+            "description": "Whether or not the vault health check is enabled"
+          }
+        ],
+        "name": "HashicorpVaultHealthExtension",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.vault.hashicorp.HashicorpVaultHealthExtension"
+      },
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.spi.security.Vault"
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.PrivateKeyResolver"
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.CertificateResolver"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Hashicorp Vault",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.vault.hashicorp.HashicorpVaultExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:vault-hashicorp",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.callback.ControlPlaneApiUrl"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.system.Hostname",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.transferprocess.TransferProcessService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.control.configuration.ControlApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Control Plane API",
+        "type": "extension",
+        "overview": " {@link ControlPlaneApiExtension } exposes HTTP endpoints for internal interaction with the Control Plane\n",
+        "className": "org.eclipse.edc.connector.api.ControlPlaneApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:control-plane-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.api.client.spi.transferprocess.TransferProcessApiClient"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Control Plane HTTP API client",
+        "type": "extension",
+        "overview": " Extensions that contains clients for Control Plane HTTP APIs\n",
+        "className": "org.eclipse.edc.connector.api.client.ControlPlaneApiClientExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:control-plane-api-client",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.spi.callback.CallbackProtocolResolverRegistry"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.event.EventRouter",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.monitor.Monitor",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.callback.CallbackRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Callback dispatcher extension",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.callback.dispatcher.CallbackEventDispatcherExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:callback-event-dispatcher",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.callback.CallbackProtocolResolverRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.Vault",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Callback dispatcher http extension",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.callback.dispatcher.http.CallbackEventDispatcherHttpExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:callback-http-dispatcher",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.spi.callback.CallbackRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Static callbacks extension",
+        "type": "extension",
+        "overview": " Extension for configuring the static endpoints for callbacks\n",
+        "className": "org.eclipse.edc.connector.callback.staticendpoint.CallbackStaticEndpointExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:callback-static-endpoint",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.provision.http.HttpProvisionerWebhookUrl"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.api.auth.spi.AuthenticationService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.transferprocess.TransferProcessService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.system.Hostname",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "HttpWebhookExtension",
+        "type": "extension",
+        "overview": " The HTTP Provisioner extension delegates to HTTP endpoints to perform provision operations.\n",
+        "className": "org.eclipse.edc.connector.provision.http.HttpWebhookExtension"
+      },
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.policy.engine.spi.PolicyEngine",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.provision.http.HttpProvisionerWebhookUrl",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "HTTP Provisioning",
+        "type": "extension",
+        "overview": " The HTTP Provisioner extension delegates to HTTP endpoints to perform provision operations.\n",
+        "className": "org.eclipse.edc.connector.provision.http.HttpProvisionerExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:provision-http",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.Vault",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.PrivateKeyResolver",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.flow.DataFlowManager",
+            "required": true
+          },
+          {
+            "service": "java.time.Clock",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.dataplane.spi.security.DataEncrypter",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.client.DataPlaneClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.control.configuration.ControlApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneSelectorClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.dataplane.spi.token.ConsumerPullTokenExpirationDateFunction",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.callback.ControlPlaneApiUrl",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Transfer Data Plane Core",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.transfer.dataplane.TransferDataPlaneCoreExtension"
+      },
+      {
+        "categories": [],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.transfer.dataplane.spi.security.DataEncrypter"
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.dataplane.spi.token.ConsumerPullTokenExpirationDateFunction"
+          }
+        ],
+        "references": [
+          {
+            "service": "java.time.Clock",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "TransferDataPlaneDefaultServicesExtension",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.transfer.dataplane.TransferDataPlaneDefaultServicesExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:transfer-data-plane",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceReceiverRegistry",
+            "required": true
+          },
+          {
+            "service": "okhttp3.OkHttpClient",
+            "required": true
+          },
+          {
+            "service": "dev.failsafe.RetryPolicy<java.lang.Object>",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.observe.TransferProcessObservable",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.receiver.http.dynamic.endpoint",
+            "required": false,
+            "type": "string",
+            "description": "Fallback endpoint when url is missing the the transfer process"
+          },
+          {
+            "key": "edc.receiver.http.dynamic.auth-key",
+            "required": false,
+            "type": "string",
+            "description": "Header name that will be sent with the EDR"
+          },
+          {
+            "key": "edc.receiver.http.dynamic.auth-code",
+            "required": false,
+            "type": "string",
+            "description": "Header value that will be sent with the EDR"
+          }
+        ],
+        "name": "Http Dynamic Endpoint Data Reference Receiver",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.receiver.http.dynamic.HttpDynamicEndpointDataReferenceReceiverExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:transfer-pull-http-dynamic-receiver",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.edr.EndpointDataReferenceReceiverRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.receiver.http.endpoint",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.receiver.http.auth-key",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.receiver.http.auth-code",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "Http Endpoint Data Reference Receiver",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.receiver.http.HttpEndpointDataReferenceReceiverExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:transfer-pull-http-receiver",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.security.PrivateKeyResolver",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Identity Did Core",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.iam.did.IdentityDidCoreExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:identity-did-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.spi.iam.IdentityService"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.iam.did.spi.credentials.CredentialsVerifier",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.PrivateKeyResolver",
+            "required": true
+          },
+          {
+            "service": "java.time.Clock",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Distributed Identity Service",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.iam.did.service.DecentralizedIdentityServiceExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:identity-did-service",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.iam.did.web.use.https",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "Web DID",
+        "type": "extension",
+        "overview": " Initializes support for resolving Web DIDs.\n",
+        "className": "org.eclipse.edc.iam.did.web.WebDidExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:identity-did-web",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "OAuth2 Client",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.iam.oauth2.Oauth2ClientExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:oauth2-client",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.spi.iam.IdentityService"
+          },
+          {
+            "service": "org.eclipse.edc.iam.oauth2.spi.Oauth2JwtDecoratorRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.iam.oauth2.spi.Oauth2ValidationRulesRegistry"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.PrivateKeyResolver",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.CertificateResolver",
+            "required": true
+          },
+          {
+            "service": "java.time.Clock",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.iam.oauth2.spi.CredentialsRequestAdditionalParametersProvider",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.oauth.provider.jwks.url",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.oauth.provider.audience",
+            "required": false,
+            "type": "string",
+            "description": "outgoing tokens 'aud' claim value, by default it's the connector id"
+          },
+          {
+            "key": "edc.oauth.endpoint.audience",
+            "required": false,
+            "type": "string",
+            "description": "incoming tokens 'aud' claim required value, by default it's the provider audience value"
+          },
+          {
+            "key": "edc.oauth.public.key.alias",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.oauth.certificate.alias",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.oauth.private.key.alias",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.oauth.provider.jwks.refresh",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.oauth.token.url",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.oauth.token.expiration",
+            "required": false,
+            "type": "string",
+            "description": "Token expiration in minutes. By default is 5 minutes"
+          },
+          {
+            "key": "edc.oauth.client.id",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.oauth.validation.nbf.leeway",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "OAuth2 Identity Service",
+        "type": "extension",
+        "overview": " Provides OAuth2 client credentials flow support.\n",
+        "className": "org.eclipse.edc.iam.oauth2.Oauth2ServiceExtension"
+      },
+      {
+        "categories": [],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.iam.oauth2.spi.CredentialsRequestAdditionalParametersProvider"
+          }
+        ],
+        "references": [],
+        "configuration": [],
+        "name": "Oauth2ServiceDefaultServicesExtension",
+        "type": "extension",
+        "overview": " Provides OAuth2 client credentials flow support.\n",
+        "className": "org.eclipse.edc.iam.oauth2.Oauth2ServiceDefaultServicesExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:oauth2-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.spi.iam.TokenDecorator"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.iam.oauth2.spi.Oauth2JwtDecoratorRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.iam.token.scope",
+            "required": false,
+            "type": "string",
+            "description": "The value of the scope claim that is passed to DAPS to obtain a DAT"
+          }
+        ],
+        "name": "DAPS",
+        "type": "extension",
+        "overview": " Provides specialization of Oauth2 extension to interact with DAPS instance\n\n @deprecated This DAPS specific extension will be deleted and be replaced by configuration values\n",
+        "className": "org.eclipse.edc.iam.oauth2.daps.DapsExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:oauth2-daps",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Commons Connection Pool",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.sql.pool.commons.CommonsConnectionPoolServiceExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:sql-pool-apache-commons",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.transform.ManagementApiTypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.asset.AssetService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.asset.DataAddressResolver",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Management API: Asset",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.api.management.asset.AssetApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:asset-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.transform.ManagementApiTypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.catalog.CatalogService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Management API: Catalog",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.api.management.catalog.CatalogApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:catalog-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.transform.ManagementApiTypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.contractagreement.ContractAgreementService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Management API: Contract Agreement",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.api.management.contractagreement.ContractAgreementApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:contract-agreement-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.transform.ManagementApiTypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.contractdefinition.ContractDefinitionService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Management API: Contract Definition",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.api.management.contractdefinition.ContractDefinitionApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:contract-definition-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.transform.ManagementApiTypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Management API: Contract Negotiation",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.api.management.contractnegotiation.ContractNegotiationApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:contract-negotiation-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.policydefinition.PolicyDefinitionService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Management API: Policy Definition",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.api.management.policy.PolicyDefinitionApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:policy-definition-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.web.spi.WebService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.ManagementApiConfiguration",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.api.management.configuration.transform.ManagementApiTypeTransformerRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.spi.transferprocess.TransferProcessService",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Management API: Transfer Process",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.api.management.transferprocess.TransferProcessApiExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:transfer-process-api",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [],
+        "references": [
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.provision.ResourceManifestGenerator",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.provision.ProvisionManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.PrivateKeyResolver",
+            "required": true
+          },
+          {
+            "service": "java.time.Clock",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.Vault",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "Oauth2 Provision (DEPRECATED: please use 'data-plane-http-oauth2' instead)",
+        "type": "extension",
+        "overview": " This extension has been deprecated in favor of \"data-plane-http-oauth2\"\n\n @deprecated please use 'data-plane-http-oauth2' instead\n",
+        "className": "org.eclipse.edc.connector.provision.oauth2.Oauth2ProvisionExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:provision-oauth2-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.spi.asset.AssetIndex"
+          },
+          {
+            "service": "org.eclipse.edc.spi.asset.DataAddressResolver"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.store.sql.assetindex.schema.AssetStatements",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.sql.QueryExecutor",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "SQL asset index",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.store.sql.assetindex.SqlAssetIndexServiceExtension"
+      }
+    ],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.connector.store.sql.assetindex.schema.AssetStatements"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:asset-index-sql",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.offer.store.ContractDefinitionStore"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.store.sql.contractdefinition.schema.ContractDefinitionStatements",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.sql.QueryExecutor",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.datasource.contractdefinition.name",
+            "required": true,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "SQL contract definition store",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.store.sql.contractdefinition.SqlContractDefinitionStoreExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:contract-definition-store-sql",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.contract.spi.negotiation.store.ContractNegotiationStore"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext",
+            "required": true
+          },
+          {
+            "service": "java.time.Clock",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.store.sql.contractnegotiation.store.schema.ContractNegotiationStatements",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.sql.QueryExecutor",
+            "required": true
+          }
+        ],
+        "configuration": [],
+        "name": "SQL contract negotiation store",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.store.sql.contractnegotiation.SqlContractNegotiationStoreExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:contract-negotiation-store-sql",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.policy.spi.store.PolicyDefinitionStore"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.store.sql.policydefinition.store.schema.SqlPolicyStoreStatements",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.sql.QueryExecutor",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.datasource.policy.name",
+            "required": true,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "SQL policy store",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.store.sql.policydefinition.SqlPolicyStoreExtension"
+      }
+    ],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.connector.store.sql.policydefinition.store.schema.SqlPolicyStoreStatements"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:policy-definition-store-sql",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.transfer.spi.store.TransferProcessStore"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext",
+            "required": true
+          },
+          {
+            "service": "java.time.Clock",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.store.sql.transferprocess.store.schema.TransferProcessStoreStatements",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.sql.QueryExecutor",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.datasource.transferprocess.name",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "SQL transfer process store",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.store.sql.transferprocess.SqlTransferProcessStoreExtension"
+      }
+    ],
+    "extensionPoints": [
+      {
+        "service": "org.eclipse.edc.connector.store.sql.transferprocess.store.schema.TransferProcessStoreStatements"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:transfer-process-store-sql",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.spi.store.DataPlaneStore"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.store.sql.schema.DataPlaneStatements",
+            "required": false
+          },
+          {
+            "service": "java.time.Clock",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.sql.QueryExecutor",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.datasource.dataplane.name",
+            "required": false,
+            "type": "string",
+            "description": "Name of the datasource to use for accessing data plane store"
+          }
+        ],
+        "name": "Sql Data Plane Store",
+        "type": "extension",
+        "overview": " Provides Sql Store for Data Plane Flow Requests states\n",
+        "className": "org.eclipse.edc.connector.dataplane.store.sql.SqlDataPlaneStoreExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:data-plane-store-sql",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  },
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          ""
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.dataplane.selector.store.sql.schema.DataPlaneInstanceStatements",
+            "required": false
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.sql.QueryExecutor",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.datasource.dataplaneinstance.name",
+            "required": false,
+            "type": "string",
+            "description": "Name of the datasource to use for accessing data plane instances"
+          }
+        ],
+        "name": "Sql Data Plane Instance Store",
+        "type": "extension",
+        "overview": " Extensions that expose an implementation of {@link DataPlaneInstanceStore} that uses SQL as backend storage\n",
+        "className": "org.eclipse.edc.connector.dataplane.selector.store.sql.SqlDataPlaneInstanceStoreExtension"
+      }
+    ],
+    "extensionPoints": [],
+    "modulePath": "org.eclipse.edc:data-plane-instance-store-sql",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  }
+]

--- a/plugins/autodoc/autodoc-converters/src/test/resources/invalid_manifest.json
+++ b/plugins/autodoc/autodoc-converters/src/test/resources/invalid_manifest.json
@@ -1,0 +1,3 @@
+{
+  "lorem": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus fermentum augue venenatis sem egestas ullamcorper. Curabitur fermentum id diam vitae suscipit. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum vehicula maximus suscipit. Donec pretium sem a viverra sollicitudin. Suspendisse ac vestibulum justo. Fusce quis tristique urna. Mauris auctor, urna nec malesuada tincidunt, enim leo venenatis nibh, rutrum varius diam urna quis turpis. Maecenas posuere finibus purus ut efficitur. Phasellus faucibus odio tortor, vitae dignissim dolor congue quis. Pellentesque ac condimentum massa. In consectetur urna sit amet condimentum dapibus."
+}

--- a/plugins/autodoc/autodoc-converters/src/test/resources/simple_manifest.json
+++ b/plugins/autodoc/autodoc-converters/src/test/resources/simple_manifest.json
@@ -1,0 +1,163 @@
+[
+  {
+    "categories": [
+      ""
+    ],
+    "extensions": [
+      {
+        "categories": [
+          "test-category"
+        ],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.spi.system.Hostname"
+          },
+          {
+            "service": "org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.spi.command.CommandHandlerRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.spi.agent.ParticipantAgentService"
+          },
+          {
+            "service": "org.eclipse.edc.policy.engine.spi.RuleBindingRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.policy.engine.spi.PolicyEngine"
+          },
+          {
+            "service": "org.eclipse.edc.spi.event.EventRouter"
+          },
+          {
+            "service": "org.eclipse.edc.spi.system.health.HealthCheckService"
+          },
+          {
+            "service": "org.eclipse.edc.transform.spi.TypeTransformerRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry"
+          }
+        ],
+        "references": [
+          {
+            "service": "org.eclipse.edc.spi.system.ExecutorInstrumentation",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.PrivateKeyResolver",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.connector.core.event.EventExecutorServiceContainer",
+            "required": true
+          },
+          {
+            "service": "org.eclipse.edc.spi.types.TypeManager",
+            "required": true
+          }
+        ],
+        "configuration": [
+          {
+            "key": "edc.core.system.health.check.liveness-period",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.core.system.health.check.startup-period",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.core.system.health.check.readiness-period",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.core.system.health.check.threadpool-size",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.hostname",
+            "required": false,
+            "type": "string",
+            "description": ""
+          },
+          {
+            "key": "edc.agent.identity.key",
+            "required": false,
+            "type": "string",
+            "description": ""
+          }
+        ],
+        "name": "Core Services",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.core.CoreServicesExtension"
+      },
+      {
+        "categories": [],
+        "provides": [
+          {
+            "service": "org.eclipse.edc.transaction.spi.TransactionContext"
+          },
+          {
+            "service": "org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry"
+          },
+          {
+            "service": "org.eclipse.edc.spi.system.ExecutorInstrumentation"
+          },
+          {
+            "service": "org.eclipse.edc.connector.core.event.EventExecutorServiceContainer"
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.Vault"
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.PrivateKeyResolver"
+          },
+          {
+            "service": "org.eclipse.edc.spi.security.CertificateResolver"
+          },
+          {
+            "service": "org.eclipse.edc.spi.http.EdcHttpClient"
+          },
+          {
+            "service": "okhttp3.OkHttpClient"
+          },
+          {
+            "service": "dev.failsafe.RetryPolicy<T>"
+          }
+        ],
+        "references": [
+          {
+            "service": "okhttp3.EventListener",
+            "required": false
+          }
+        ],
+        "configuration": [],
+        "name": "CoreDefaultServicesExtension",
+        "type": "extension",
+        "overview": "No overview provided.",
+        "className": "org.eclipse.edc.connector.core.CoreDefaultServicesExtension"
+      }
+    ],
+    "extensionPoints": [
+      {
+        "service": "foo.service"
+      },
+      {
+        "service": "org.test.bar.BarService"
+      }
+    ],
+    "modulePath": "org.eclipse.edc:connector-core",
+    "version": "0.2.1-SNAPSHOT",
+    "name": null
+  }
+]

--- a/plugins/autodoc/autodoc-plugin/build.gradle.kts
+++ b/plugins/autodoc/autodoc-plugin/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation(libs.jackson.annotations)
     implementation(libs.jackson.databind)
     implementation(libs.jackson.datatypeJsr310)
+    implementation(project(":plugins:autodoc:autodoc-converters"))
 }
 
 val group: String by project

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
@@ -1,14 +1,14 @@
 /*
- *  Copyright (c) 2022 Microsoft Corporation
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  *
- *  Contributors:
- *       Microsoft Corporation - initial API and implementation
+ * Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
@@ -14,7 +14,8 @@
 
 package org.eclipse.edc.plugins.autodoc;
 
-import org.eclipse.edc.plugins.autodoc.merge.MergeManifestsTask;
+import org.eclipse.edc.plugins.autodoc.tasks.MarkdownRendererTask;
+import org.eclipse.edc.plugins.autodoc.tasks.MergeManifestsTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
@@ -37,7 +38,8 @@ public class AutodocPlugin implements Plugin<Project> {
 
         // registers a "named" task, that does nothing, except depend on the compileTask, which then runs the annotation processor
         project.getTasks().register("autodoc", t -> t.dependsOn("compileJava"));
-        project.getTasks().register("mergeManifest", MergeManifestsTask.class, t -> t.dependsOn("autodoc"));
+        project.getTasks().register("mergeManifest", MergeManifestsTask.class, t -> t.dependsOn("autodoc").finalizedBy("doc2md"));
+        project.getTasks().register("doc2md", MarkdownRendererTask.class, t -> t.dependsOn("autodoc"));
 
     }
 

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/JsonFileAppender.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/JsonFileAppender.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.plugins.autodoc.merge;
+package org.eclipse.edc.plugins.autodoc.tasks;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MarkdownRendererTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MarkdownRendererTask.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.autodoc.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.plugins.autodoc.json.JsonManifestReader;
+import org.eclipse.edc.plugins.autodoc.markdown.MarkdownManifestRenderer;
+import org.eclipse.edc.plugins.autodoc.spi.ManifestWriter;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static java.lang.String.format;
+
+public class MarkdownRendererTask extends DefaultTask {
+
+    private final JsonManifestReader reader = new JsonManifestReader(new ObjectMapper());
+
+    @TaskAction
+    public void renderMarkdown() {
+
+        var buildDir = getProject().getBuildDir();
+
+        File manifest;
+        if (getProject().getRootProject().equals(getProject())) {
+            manifest = Path.of(buildDir.getAbsolutePath(), "manifest.json").toFile();
+        } else {
+            manifest = Path.of(buildDir.getAbsolutePath(), "edc.json").toFile();
+        }
+
+        if (manifest.exists()) {
+            var outputFile = new File(getProject().getBuildDir(), getProject().getName() + ".md");
+            try (
+                    var fos = new FileOutputStream(outputFile);
+                    var fis = new FileInputStream(manifest)
+            ) {
+                var writer = new ManifestWriter(new MarkdownManifestRenderer(fos));
+                getLogger().lifecycle(format("Rendering %s for input %s", outputFile, manifest));
+                try (var os = writer.convert(reader.read(fis))) {
+                    os.flush();
+                }
+            } catch (IOException e) {
+                throw new GradleException("Error rendering Markdown", e);
+            }
+        }
+    }
+}

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MergeManifestsTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MergeManifestsTask.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.plugins.autodoc.merge;
+package org.eclipse.edc.plugins.autodoc.tasks;
 
 import org.eclipse.edc.plugins.autodoc.AutodocExtension;
 import org.gradle.api.DefaultTask;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "GradlePlugins"
 
 include(":plugins:autodoc:autodoc-plugin")
 include(":plugins:autodoc:autodoc-processor")
+include(":plugins:autodoc:autodoc-converters")
 include(":plugins:edc-build")
 include(":plugins:module-names")
 include(":plugins:openapi-merger")


### PR DESCRIPTION
## What this PR changes/adds

Adds a task `doc2md`, that takes the output JSON of `autodoc` and converts it into a Markdown file in the same directory (i.e. the `build/` directory).

If there is a `manifest.json` in the root `build/` dir, then that gets converted as well.


## Why it does that

Easy and automatic generation of documentation.

## Further notes

- merging all the different `edc.json` files is async, so `./gradlew mergeManifest` and `./gradlew doc2md` _must_ be separate gradle invocations
- there is no dependency `doc2md` -> `mergeManifest` whatsoever

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

