### PR TITLE
feat: download transitive autodoc manifests

### DIFF
--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocExtension.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocExtension.java
@@ -29,4 +29,12 @@ public abstract class AutodocExtension {
      */
     public abstract Property<String> getProcessorVersion();
 
+    /**
+     * Optional input to specify, where additional autodoc manifests that are to be merged, are located on the filesystem.
+     * Use this, if you have a directory that contains multiple autodoc manifests, e.g. of third-party or transitive deps.
+     * <p>
+     * If this is set, the merge task will take all manifests found in this directory and append them to the {@code manifest.json} file.
+     */
+    public abstract Property<File> getAdditionalInputDirectory();
+
 }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocExtension.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocExtension.java
@@ -36,8 +36,19 @@ public abstract class AutodocExtension {
      * Use this, if you have a directory that contains multiple autodoc manifests, e.g. of third-party or transitive deps.
      * <p>
      * If this is set, the merge task will take all manifests found in this directory and append them to the {@code manifest.json} file.
+     * Usually, this points to wherever the downloaded manifests are store.
+     *
+     * @see AutodocExtension#getDownloadDirectory()
      */
     public abstract Property<File> getAdditionalInputDirectory();
+
+    /**
+     * Retrieves the directory where downloaded manifests are to be stored. Defaults to {@code <rootProject>/build/manifests}
+     *
+     * @return The property representing the download directory, or null if not specified.
+     */
+    public abstract Property<File> getDownloadDirectory();
+
 
     /**
      * Determines whether to include transitive dependencies in the merge process.

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocExtension.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocExtension.java
@@ -19,6 +19,8 @@ import org.gradle.api.provider.Property;
 import java.io.File;
 
 public abstract class AutodocExtension {
+    private boolean includeTransitive = true;
+
     /**
      * Overrides the default output directory relative to the current project dir
      */
@@ -37,4 +39,18 @@ public abstract class AutodocExtension {
      */
     public abstract Property<File> getAdditionalInputDirectory();
 
+    /**
+     * Determines whether to include transitive dependencies in the merge process.
+     * If set to {@code true}, the merge task will download the manifests of transitive (EDC) dependencies and include them in the merged manifest.
+     * If set to {@code false}, only the direct dependencies will be merged.
+     *
+     * @return {@code true} if transitive dependencies should be included, {@code false} otherwise.
+     */
+    public boolean isIncludeTransitive() {
+        return includeTransitive;
+    }
+
+    public void setIncludeTransitive(boolean includeTransitive) {
+        this.includeTransitive = includeTransitive;
+    }
 }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
@@ -38,9 +38,8 @@ public class AutodocPlugin implements Plugin<Project> {
 
         // registers a "named" task, that does nothing, except depend on the compileTask, which then runs the annotation processor
         project.getTasks().register("autodoc", t -> t.dependsOn("compileJava"));
-        project.getTasks().register("mergeManifest", MergeManifestsTask.class, t -> t.dependsOn("autodoc").finalizedBy("doc2md"));
+        project.getTasks().register("mergeManifest", MergeManifestsTask.class, t -> t.dependsOn("autodoc"));
         project.getTasks().register("doc2md", MarkdownRendererTask.class, t -> t.dependsOn("autodoc"));
 
     }
-
 }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.plugins.autodoc;
 
+import org.eclipse.edc.plugins.autodoc.tasks.ManifestDownloadTask;
 import org.eclipse.edc.plugins.autodoc.tasks.MarkdownRendererTask;
 import org.eclipse.edc.plugins.autodoc.tasks.MergeManifestsTask;
 import org.gradle.api.Plugin;
@@ -26,6 +27,7 @@ import java.util.List;
  */
 public class AutodocPlugin implements Plugin<Project> {
 
+    public static final String GROUP_NAME = "autodoc";
     private final List<String> exclusions = List.of("version-catalog", "edc-build", "module-names", "openapi-merger", "test-summary", "autodoc-plugin", "autodoc-processor");
 
     @Override
@@ -37,9 +39,9 @@ public class AutodocPlugin implements Plugin<Project> {
         }
 
         // registers a "named" task, that does nothing, except depend on the compileTask, which then runs the annotation processor
-        project.getTasks().register("autodoc", t -> t.dependsOn("compileJava"));
-        project.getTasks().register("mergeManifest", MergeManifestsTask.class, t -> t.dependsOn("autodoc"));
-        project.getTasks().register("doc2md", MarkdownRendererTask.class, t -> t.dependsOn("autodoc"));
-
+        project.getTasks().register("autodoc", t -> t.dependsOn("compileJava").setGroup(GROUP_NAME));
+        project.getTasks().register("mergeManifest", MergeManifestsTask.class, t -> t.dependsOn(GROUP_NAME).setGroup(GROUP_NAME));
+        project.getTasks().register("doc2md", MarkdownRendererTask.class, t -> t.dependsOn(GROUP_NAME).setGroup(GROUP_NAME));
+        project.getTasks().register("downloadManifests", ManifestDownloadTask.class, t -> t.setGroup(GROUP_NAME));
     }
 }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
@@ -28,6 +28,7 @@ import java.util.List;
 public class AutodocPlugin implements Plugin<Project> {
 
     public static final String GROUP_NAME = "autodoc";
+    public static final String AUTODOC_TASK_NAME = "autodoc";
     private final List<String> exclusions = List.of("version-catalog", "edc-build", "module-names", "openapi-merger", "test-summary", "autodoc-plugin", "autodoc-processor");
 
     @Override
@@ -39,9 +40,9 @@ public class AutodocPlugin implements Plugin<Project> {
         }
 
         // registers a "named" task, that does nothing, except depend on the compileTask, which then runs the annotation processor
-        project.getTasks().register("autodoc", t -> t.dependsOn("compileJava").setGroup(GROUP_NAME));
-        project.getTasks().register("mergeManifest", MergeManifestsTask.class, t -> t.dependsOn(GROUP_NAME).setGroup(GROUP_NAME));
-        project.getTasks().register("doc2md", MarkdownRendererTask.class, t -> t.dependsOn(GROUP_NAME).setGroup(GROUP_NAME));
-        project.getTasks().register("downloadManifests", ManifestDownloadTask.class, t -> t.setGroup(GROUP_NAME));
+        project.getTasks().register(AUTODOC_TASK_NAME, t -> t.dependsOn("compileJava").setGroup(GROUP_NAME));
+        project.getTasks().register(MergeManifestsTask.NAME, MergeManifestsTask.class, t -> t.dependsOn(AUTODOC_TASK_NAME).setGroup(GROUP_NAME));
+        project.getTasks().register(MarkdownRendererTask.NAME, MarkdownRendererTask.class, t -> t.dependsOn(AUTODOC_TASK_NAME).setGroup(GROUP_NAME));
+        project.getTasks().register(ManifestDownloadTask.NAME, ManifestDownloadTask.class, t -> t.setGroup(GROUP_NAME));
     }
 }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/ManifestDownloadTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/ManifestDownloadTask.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.autodoc.tasks;
+
+import org.eclipse.edc.plugins.autodoc.AutodocExtension;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ManifestDownloadTask extends DefaultTask {
+
+    private static final String EDC_GROUP = "org.eclipse.edc";
+    private final HttpClient httpClient;
+
+    public ManifestDownloadTask() {
+        httpClient = HttpClient.newHttpClient();
+    }
+
+    @TaskAction
+    public void downloadManifests() {
+        var autodocExt = getProject().getExtensions().findByType(AutodocExtension.class);
+        requireNonNull(autodocExt, "AutodocExtension cannot be null");
+
+        getProject().getConfigurations()
+                .stream().flatMap(config -> config.getDependencies().stream())
+                .filter(dep -> EDC_GROUP.equals(dep.getGroup()))
+                .filter(dep -> !getExclusions().contains(dep.getName()))
+                .map(dep -> findInRepo(dep, "manifest", "json"))
+                .filter(Optional::isPresent)
+                .forEach(dt -> downloadDependency(dt.get(), getProject().getRootProject().getBuildDir().toPath().resolve("manifests")));
+    }
+
+    private String createArtifactUrl(Dependency dep, String classifier, String type, MavenArtifactRepository repo) {
+        return format("%s%s/%s/%s/%s-%s-%s.%s", repo.getUrl(), dep.getGroup().replace(".", "/"), dep.getName(), dep.getVersion(),
+                dep.getName(), dep.getVersion(), classifier, type);
+    }
+
+    private void downloadDependency(DownloadRequest dt, Path outputDirectory) {
+
+        var p = outputDirectory.resolve(dt.filename());
+        var request = HttpRequest.newBuilder().uri(dt.uri()).GET().build();
+        try {
+            var response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() != 200) {
+                getLogger().warn("Could not download {}, HTTP response: {}", dt.dependency, response);
+                return;
+            }
+            outputDirectory.toFile().mkdirs();
+            getLogger().debug("Downloading {} into {}", dt, outputDirectory);
+            try (var is = response.body(); var fos = new FileOutputStream(p.toFile())) {
+                is.transferTo(fos);
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Optional<DownloadRequest> findInRepo(Dependency dep, String classifier, String type) {
+        var repos = getProject().getRepositories().stream().toList();
+        return repos.stream()
+                .filter(repo -> repo instanceof MavenArtifactRepository)
+                .map(repo -> (MavenArtifactRepository) repo)
+                .map(repo -> {
+                    var repoUrl = createArtifactUrl(dep, classifier, type, repo);
+                    try {
+                        // we use a HEAD request, because we only want to see whether that module has a `-manifest.json`
+                        var uri = URI.create(repoUrl);
+                        var headRequest = HttpRequest.newBuilder()
+                                .uri(uri)
+                                .method("HEAD", HttpRequest.BodyPublishers.noBody())
+                                .build();
+                        var response = httpClient.send(headRequest, HttpResponse.BodyHandlers.discarding());
+                        if (response.statusCode() == 200) {
+                            return new DownloadRequest(dep, uri, classifier, type);
+                        }
+                        return null;
+                    } catch (IOException | InterruptedException | IllegalArgumentException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .findFirst();
+    }
+
+    private Set<String> getExclusions() {
+        return Set.of();
+    }
+
+    private record DownloadRequest(Dependency dependency, URI uri, String classifier, String type) {
+        @Override
+        public String toString() {
+            return "{" +
+                    "dependency=" + dependency +
+                    ", uri=" + uri +
+                    '}';
+        }
+
+        String filename() {
+            return format("%s-%s-%s.%s", dependency.getName(), dependency.getVersion(), classifier, type);
+        }
+    }
+}

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/ManifestDownloadTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/ManifestDownloadTask.java
@@ -26,7 +26,10 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -36,11 +39,17 @@ import static java.util.Objects.requireNonNull;
 
 public class ManifestDownloadTask extends DefaultTask {
 
+    public static final String NAME = "downloadManifests";
     private static final String EDC_GROUP = "org.eclipse.edc";
+    private static final Duration MAX_MANIFEST_AGE = Duration.ofHours(24);
+    private static final String MANIFEST_CLASSIFIER = "manifest";
+    private static final String MANIFEST_TYPE = "json";
     private final HttpClient httpClient;
+    private Path downloadDirectory;
 
     public ManifestDownloadTask() {
         httpClient = HttpClient.newHttpClient();
+        downloadDirectory = getProject().getRootProject().getBuildDir().toPath().resolve("manifests");
     }
 
     @TaskAction
@@ -48,21 +57,25 @@ public class ManifestDownloadTask extends DefaultTask {
         var autodocExt = getProject().getExtensions().findByType(AutodocExtension.class);
         requireNonNull(autodocExt, "AutodocExtension cannot be null");
 
+        if (autodocExt.getDownloadDirectory().isPresent()) {
+            downloadDirectory = autodocExt.getDownloadDirectory().get().toPath();
+        }
+
         getProject().getConfigurations()
                 .stream().flatMap(config -> config.getDependencies().stream())
                 .filter(dep -> EDC_GROUP.equals(dep.getGroup()))
                 .filter(dep -> !getExclusions().contains(dep.getName()))
-                .map(dep -> findInRepo(dep, "manifest", "json"))
+                .map(this::createDownloadRequest)
                 .filter(Optional::isPresent)
-                .forEach(dt -> downloadDependency(dt.get(), getProject().getRootProject().getBuildDir().toPath().resolve("manifests")));
+                .forEach(dt -> downloadDependency(dt.get(), downloadDirectory));
     }
 
-    private String createArtifactUrl(Dependency dep, String classifier, String type, MavenArtifactRepository repo) {
+    private String createArtifactUrl(Dependency dep, MavenArtifactRepository repo) {
         return format("%s%s/%s/%s/%s-%s-%s.%s", repo.getUrl(), dep.getGroup().replace(".", "/"), dep.getName(), dep.getVersion(),
-                dep.getName(), dep.getVersion(), classifier, type);
+                dep.getName(), dep.getVersion(), MANIFEST_CLASSIFIER, MANIFEST_TYPE);
     }
 
-    private void downloadDependency(DownloadRequest dt, Path outputDirectory) {
+    private void downloadDependency(DependencyDownload dt, Path outputDirectory) {
 
         var p = outputDirectory.resolve(dt.filename());
         var request = HttpRequest.newBuilder().uri(dt.uri()).GET().build();
@@ -82,13 +95,30 @@ public class ManifestDownloadTask extends DefaultTask {
         }
     }
 
-    private Optional<DownloadRequest> findInRepo(Dependency dep, String classifier, String type) {
+    /**
+     * Creates a download request for a given dependency, classifier, and type. A download request is successfully created if:
+     * <ul>
+     *     <li>the output directory does not exists</li>
+     *     <li>the file does not exist locally</li>
+     *     <li>the file exists locally, but is too old (<24hrs) </li>
+     *     <li>the file exists locally, but is not readable</li>
+     *     <li>the file is found in at least one Maven repository. MavenLocal is ignored.</li>
+     * </ul>
+     *
+     * @param dep the dependency to download
+     * @return an optional DownloadRequest if the artifact should be downloaded, otherwise an empty optional
+     */
+    private Optional<DependencyDownload> createDownloadRequest(Dependency dep) {
+        if (isLocalFileValid(dep)) {
+            getLogger().debug("Local file {} was deemed to be viable, will not download", new DependencyDownload(dep, null, MANIFEST_CLASSIFIER, MANIFEST_TYPE).filename());
+            return Optional.empty();
+        }
         var repos = getProject().getRepositories().stream().toList();
         return repos.stream()
                 .filter(repo -> repo instanceof MavenArtifactRepository)
                 .map(repo -> (MavenArtifactRepository) repo)
                 .map(repo -> {
-                    var repoUrl = createArtifactUrl(dep, classifier, type, repo);
+                    var repoUrl = createArtifactUrl(dep, repo);
                     try {
                         // we use a HEAD request, because we only want to see whether that module has a `-manifest.json`
                         var uri = URI.create(repoUrl);
@@ -98,7 +128,7 @@ public class ManifestDownloadTask extends DefaultTask {
                                 .build();
                         var response = httpClient.send(headRequest, HttpResponse.BodyHandlers.discarding());
                         if (response.statusCode() == 200) {
-                            return new DownloadRequest(dep, uri, classifier, type);
+                            return new DependencyDownload(dep, uri, MANIFEST_CLASSIFIER, MANIFEST_TYPE);
                         }
                         return null;
                     } catch (IOException | InterruptedException | IllegalArgumentException e) {
@@ -109,11 +139,36 @@ public class ManifestDownloadTask extends DefaultTask {
                 .findFirst();
     }
 
+    /**
+     * Checks if the manifest for a dependency exists locally. A local file is considered valid if:
+     * <ul>
+     *  <li>The output directory exists</li>
+     *  <li>The file exists locally and is readable</li>
+     *  <li>The file is not older than 24 hours</li>
+     * </ul>
+     *
+     * @param dep the dependency to check
+     * @return true if the local file is valid, false otherwise
+     */
+    private boolean isLocalFileValid(Dependency dep) {
+        if (!downloadDirectory.toFile().exists()) return false;
+        var filePath = downloadDirectory.resolve(new DependencyDownload(dep, null, MANIFEST_CLASSIFIER, MANIFEST_TYPE).filename());
+        var file = filePath.toFile();
+        if (!file.exists() || !file.canRead()) return false;
+
+        try {
+            var date = Files.getLastModifiedTime(filePath).toInstant();
+            return Duration.between(date, Instant.now()).compareTo(MAX_MANIFEST_AGE) <= 0;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private Set<String> getExclusions() {
         return Set.of();
     }
 
-    private record DownloadRequest(Dependency dependency, URI uri, String classifier, String type) {
+    private record DependencyDownload(Dependency dependency, URI uri, String classifier, String type) {
         @Override
         public String toString() {
             return "{" +

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MarkdownRendererTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MarkdownRendererTask.java
@@ -32,6 +32,7 @@ import static java.lang.String.format;
 
 public class MarkdownRendererTask extends DefaultTask {
 
+    public static final String NAME = "doc2md";
     private final JsonManifestReader reader = new JsonManifestReader(new ObjectMapper());
 
     @TaskAction

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MergeManifestsTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MergeManifestsTask.java
@@ -19,6 +19,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.util.internal.GFileUtils;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -52,6 +53,12 @@ public class MergeManifestsTask extends DefaultTask {
             throw new GradleException("destinationFile must be configured but was null!");
         }
 
+        // if an additional input directory was specified, lets include the files in it.
+        if (autodocExt.getAdditionalInputDirectory().isPresent() && getProject().equals(getProject().getRootProject())) {
+            var dir = autodocExt.getAdditionalInputDirectory().get();
+            var files = GFileUtils.listFiles(dir, new String[]{ "json" }, false);
+            files.forEach(f -> appender.append(destination, f));
+        }
 
         if (sourceFile.exists()) {
             appender.append(destination, sourceFile);

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MergeManifestsTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MergeManifestsTask.java
@@ -53,17 +53,21 @@ public class MergeManifestsTask extends DefaultTask {
             throw new GradleException("destinationFile must be configured but was null!");
         }
 
-        // if an additional input directory was specified, lets include the files in it.
-        if (autodocExt.getAdditionalInputDirectory().isPresent() && getProject().equals(getProject().getRootProject())) {
-            var dir = autodocExt.getAdditionalInputDirectory().get();
-            var files = GFileUtils.listFiles(dir, new String[]{ "json" }, false);
-            files.forEach(f -> appender.append(destination, f));
-        }
-
         if (sourceFile.exists()) {
             appender.append(destination, sourceFile);
         } else {
             getProject().getLogger().lifecycle("Skip project [{}] - no manifest file found", sourceFile);
+        }
+
+        // if an additional input directory was specified, lets include the files in it.
+        if (autodocExt.getAdditionalInputDirectory().isPresent() &&
+                autodocExt.getAdditionalInputDirectory().get().exists() &&
+                getProject().equals(getProject().getRootProject()) &&
+                autodocExt.isIncludeTransitive()) {
+            var dir = autodocExt.getAdditionalInputDirectory().get();
+            var files = GFileUtils.listFiles(dir, new String[]{ "json" }, false);
+            getLogger().lifecycle("Appending [{}] additional JSON files to the merged manifest", files.size());
+            files.forEach(f -> appender.append(destination, f));
         }
 
     }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MergeManifestsTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MergeManifestsTask.java
@@ -30,6 +30,7 @@ import java.util.Objects;
  */
 public class MergeManifestsTask extends DefaultTask {
 
+    public static final String NAME = "mergeManifests";
     private static final String MERGED_MANIFEST_FILENAME = "manifest.json";
     private final JsonFileAppender appender;
     private File destinationFile;

--- a/plugins/autodoc/autodoc-plugin/src/test/java/org/eclipse/edc/plugins/autodoc/AutodocPluginTest.java
+++ b/plugins/autodoc/autodoc-plugin/src/test/java/org/eclipse/edc/plugins/autodoc/AutodocPluginTest.java
@@ -14,11 +14,13 @@
 
 package org.eclipse.edc.plugins.autodoc;
 
+import org.eclipse.edc.plugins.autodoc.tasks.MergeManifestsTask;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.plugins.autodoc.AutodocPlugin.AUTODOC_TASK_NAME;
 
 
 public class AutodocPluginTest {
@@ -30,7 +32,7 @@ public class AutodocPluginTest {
 
         // Verify the result
         var tasks = project.getTasks();
-        assertThat(tasks.findByName("autodoc")).isNotNull();
-        assertThat(tasks.findByName("mergeManifest")).isNotNull();
+        assertThat(tasks.findByName(AUTODOC_TASK_NAME)).isNotNull();
+        assertThat(tasks.findByName(MergeManifestsTask.NAME)).isNotNull();
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a gradle task `downloadManifests`, that downloads the `-manifest.json` from Maven for every `org.eclipse.edc` dependency.

Downstream projects, such as Tractus-X, that have dependencies onto EDC modules, can now merge _their_ autodoc manifests with those coming from EDC.

Usually, the sequence is this:
```shell
./gradlew autodoc
./gradlew downloadManifests
./gradlew mergeManifests
./gradlew doc2md
```

which will produce a Markdown file containing documentation about the code base plus any transitive EDC dependencies.

Alternatively, they can be run together:
```shell
./gradlew autodoc downloadManifests mergeManifests doc2md --no-parallel
```

## Why it does that

easily create documentation

## Further notes

- these gradle tasks run async and potentially multithreaded, so they really should be called in separate gradle invocations or with the `--no-parallel` option


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_


