### PR TITLE
build: remove fraunhofer repository as it is not needed anymore

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -56,10 +56,10 @@ maven/mavencentral/io.swagger.parser.v3/swagger-parser-v2-converter/2.0.23, Apac
 maven/mavencentral/io.swagger.parser.v3/swagger-parser-v3/2.0.23, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.parser.v3/swagger-parser/2.0.23, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger/swagger-annotations/1.6.2, Apache-2.0, approved, #3792
-maven/mavencentral/io.swagger/swagger-compat-spec-parser/1.0.52, None, restricted, #11282
+maven/mavencentral/io.swagger/swagger-compat-spec-parser/1.0.52, None, restricted, #11479
 maven/mavencentral/io.swagger/swagger-core/1.6.1, Apache-2.0, approved, #4358
 maven/mavencentral/io.swagger/swagger-core/1.6.2, Apache-2.0, approved, #4358
-maven/mavencentral/io.swagger/swagger-models/1.6.2, LicenseRef-scancode-proprietary-license, restricted, #11330
+maven/mavencentral/io.swagger/swagger-models/1.6.2, LicenseRef-scancode-proprietary-license, restricted, #11403
 maven/mavencentral/io.swagger/swagger-parser/1.0.52, Apache-2.0, approved, #4359
 maven/mavencentral/jakarta.activation/jakarta.activation-api/1.2.1, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.validation/jakarta.validation-api/2.0.2, Apache-2.0, approved, ee4j.validation

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/RepositoriesConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/RepositoriesConvention.java
@@ -29,6 +29,5 @@ class RepositoriesConvention implements EdcConvention {
         handler.mavenLocal();
         handler.maven(r -> r.setUrl(URI.create("https://oss.sonatype.org/content/repositories/snapshots/")));
         handler.mavenCentral();
-        handler.maven(r -> r.setUrl(URI.create("https://maven.iais.fraunhofer.de/artifactory/eis-ids-public/")));
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Removes the fraunhofer repository

## Why it does that

It's not needed anymore and sometimes it returns errors that block the release process (e.g. https://github.com/eclipse-edc/Release/actions/runs/6844409607/job/18617673400)

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
