### PR TITLE
feat(autodoc): suppoort context property on autodoc

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -85,7 +85,7 @@ maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.2, Apache-2.0, appro
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.4, Apache-2.0, approved, CQ11716
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.23.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.checkerframework/checker-compat-qual/2.5.2, MIT, approved, clearlydefined
+maven/mavencentral/org.checkerframework/checker-compat-qual/2.5.2, GPL-2.0-only with Classpath-Exception-2.0, approved, #11598
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.mojo/animal-sniffer-annotations/1.17, MIT, approved, clearlydefined
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.3.2-SNAPSHOT, Apache-2.0, approved, technology.edc

--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ExtensionIntrospector.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ExtensionIntrospector.java
@@ -49,6 +49,7 @@ import static org.eclipse.edc.plugins.autodoc.core.processor.compiler.ElementFun
  * Contains methods for introspecting any given extension (represented by an {@link Element}) using the Java Compiler API.
  */
 public class ExtensionIntrospector {
+    public static final String CONTEXT_ATTRIBUTE = "context";
     private final Elements elementUtils;
 
     public ExtensionIntrospector(Elements elementUtils) {
@@ -133,7 +134,7 @@ public class ExtensionIntrospector {
      */
     private ConfigurationSetting createConfigurationSetting(VariableElement settingElement) {
         var settingMirror = mirrorFor(Setting.class, settingElement);
-        var prefix = attributeValue(String.class, "context", settingMirror, elementUtils);
+        var prefix = attributeValue(String.class, CONTEXT_ATTRIBUTE, settingMirror, elementUtils);
         if (prefix.isEmpty()) {
             prefix = resolveConfigurationPrefix(settingElement);
         }

--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ExtensionIntrospector.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ExtensionIntrospector.java
@@ -132,9 +132,13 @@ public class ExtensionIntrospector {
      * Maps a {@link ConfigurationSetting} from an {@link Setting} annotation.
      */
     private ConfigurationSetting createConfigurationSetting(VariableElement settingElement) {
-        var prefix = resolveConfigurationPrefix(settingElement);
-        var keyValue = prefix + settingElement.getConstantValue().toString();
         var settingMirror = mirrorFor(Setting.class, settingElement);
+        var prefix = attributeValue(String.class, "context", settingMirror, elementUtils);
+        if (prefix.isEmpty()) {
+            prefix = resolveConfigurationPrefix(settingElement);
+        }
+
+        var keyValue = prefix + settingElement.getConstantValue().toString();
 
         return ConfigurationSetting.Builder.newInstance().key(keyValue)
                 .description(attributeValue(String.class, "value", settingMirror, elementUtils))

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/Constants.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/Constants.java
@@ -19,4 +19,9 @@ public interface Constants {
     String TEST_SETTING_KEY = "edc.test.setting";
     String TEST_SETTING_DEFAULT_VALUE = "default value";
     String TEST_SPI_MODULE = "Test SPI Module";
+
+    String TEST_FIELD_PREFIX_SETTING_KEY = "edc.prefix.field.";
+    String TEST_CLASS_PREFIX_SETTING_KEY = "edc.prefix.class.";
+    String TEST_SETTING_ID_KEY = "id";
+
 }

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessorExtensionTest.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessorExtensionTest.java
@@ -19,8 +19,10 @@ import org.eclipse.edc.plugins.autodoc.core.processor.testextensions.OptionalSer
 import org.eclipse.edc.plugins.autodoc.core.processor.testextensions.RequiredService;
 import org.eclipse.edc.plugins.autodoc.core.processor.testextensions.SampleExtensionWithoutAnnotation;
 import org.eclipse.edc.plugins.autodoc.core.processor.testextensions.SecondExtension;
+import org.eclipse.edc.plugins.autodoc.core.processor.testextensions.SettingContextExtension;
 import org.eclipse.edc.plugins.autodoc.core.processor.testextensions.SomeOtherService;
 import org.eclipse.edc.plugins.autodoc.core.processor.testextensions.SomeService;
+import org.eclipse.edc.runtime.metamodel.domain.ConfigurationSetting;
 import org.eclipse.edc.runtime.metamodel.domain.EdcServiceExtension;
 import org.eclipse.edc.runtime.metamodel.domain.Service;
 import org.eclipse.edc.runtime.metamodel.domain.ServiceReference;
@@ -34,7 +36,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_CLASS_PREFIX_SETTING_KEY;
+import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_FIELD_PREFIX_SETTING_KEY;
 import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_SETTING_DEFAULT_VALUE;
+import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_SETTING_ID_KEY;
 import static org.eclipse.edc.plugins.autodoc.core.processor.TestFunctions.filterManifest;
 import static org.eclipse.edc.plugins.autodoc.core.processor.TestFunctions.readManifest;
 
@@ -46,10 +51,10 @@ class EdcModuleProcessorExtensionTest extends EdcModuleProcessorTest {
         var modules = readManifest(filterManifest(tempDir));
         assertThat(modules).hasSize(1);
         assertThat(modules.get(0).getExtensions())
-                .hasSize(2)
+                .hasSize(3)
                 .extracting(EdcServiceExtension::getName)
                 .containsOnly(SampleExtensionWithoutAnnotation.class.getSimpleName(),
-                        SecondExtension.class.getSimpleName())
+                        SecondExtension.class.getSimpleName(), SettingContextExtension.class.getSimpleName())
                 .doesNotContain(NotAnExtension.class.getName()); //explicitly exclude this
     }
 
@@ -65,7 +70,7 @@ class EdcModuleProcessorExtensionTest extends EdcModuleProcessorTest {
                 .allSatisfy(e -> assertThat(e.getCategories()).isNotNull().isEmpty())
                 .allSatisfy(e -> assertThat(e.getOverview()).isNull())
                 .extracting(EdcServiceExtension::getName)
-                .containsOnly(SampleExtensionWithoutAnnotation.class.getSimpleName(), SecondExtension.class.getSimpleName());
+                .containsOnly(SampleExtensionWithoutAnnotation.class.getSimpleName(), SecondExtension.class.getSimpleName(), SettingContextExtension.class.getSimpleName());
 
         var ext1 = extensions.stream().filter(e -> e.getName().equals(SampleExtensionWithoutAnnotation.class.getSimpleName()))
                 .findFirst()
@@ -100,6 +105,25 @@ class EdcModuleProcessorExtensionTest extends EdcModuleProcessorTest {
                 .containsOnly(new ServiceReference(SomeService.class.getName(), true));
 
         assertThat(ext2.getConfiguration()).isEmpty();
+    }
+
+    @Test
+    void verifyManifestContainsCorrectSettingsWithContext() {
+        task.call();
+
+        var modules = readManifest(filterManifest(tempDir));
+        assertThat(modules).hasSize(1);
+        var extensions = modules.get(0).getExtensions();
+
+        var ext1 = extensions.stream().filter(e -> e.getName().equals(SettingContextExtension.class.getSimpleName()))
+                .findFirst()
+                .orElseThrow();
+
+
+        assertThat(ext1.getConfiguration())
+                .extracting(ConfigurationSetting::getKey)
+                .contains(TEST_CLASS_PREFIX_SETTING_KEY + TEST_SETTING_ID_KEY, TEST_FIELD_PREFIX_SETTING_KEY + TEST_SETTING_ID_KEY);
+
     }
 
     @Override

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testextensions/SettingContextExtension.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testextensions/SettingContextExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Microsoft Corporation
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Microsoft Corporation - initial API and implementation
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */
 

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testextensions/SettingContextExtension.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testextensions/SettingContextExtension.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.autodoc.core.processor.testextensions;
+
+import org.eclipse.edc.plugins.autodoc.core.processor.Constants;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
+import org.eclipse.edc.spi.system.ServiceExtension;
+
+import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_CLASS_PREFIX_SETTING_KEY;
+import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_FIELD_PREFIX_SETTING_KEY;
+
+
+@SettingContext(TEST_CLASS_PREFIX_SETTING_KEY)
+public class SettingContextExtension implements ServiceExtension {
+
+    @Setting(context = TEST_FIELD_PREFIX_SETTING_KEY)
+    private static final String TEST_FIELD_PREFIX_SETTING = Constants.TEST_SETTING_ID_KEY;
+
+    @Setting
+    private static final String TEST_CLASS_PREFIX_SETTING = Constants.TEST_SETTING_ID_KEY;
+
+}


### PR DESCRIPTION
## What this PR changes/adds

Support the `context` property in Setting annotation which allows to provide a custom `prefix` for the `Setting`  in the autodoc.

If no context is provider the behavior is the same as before.

## Why it does that

documentation


## Linked Issue(s)

Closes #191 


