### PR TITLE
build: add output to createVersions task

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -65,21 +65,27 @@ val createVersions = tasks.register("createVersions") {
         .resolve("edcbuild")
     folder.mkdirs()
 
-    versionCatalogs.find("libs")
-        .ifPresent { catalog ->
-            val head = "package org.eclipse.edc.plugins.edcbuild;\npublic interface Versions {\n"
-            val tail = "\n}";
+    val versionsClassFile = folder.resolve("Versions.java");
+    outputs.file(versionsClassFile)
 
-            val constants = listOf("jupiter", "mockito", "assertj")
-                .mapNotNull { name ->
-                    catalog.findVersion(name)
-                        .map { version -> "    String %s = \"%s\";".format(name.toUpperCase(), version) }
-                        .orElse(null)
-                }
-                .joinToString("\n", head, tail)
+    doLast {
+        versionCatalogs.find("libs")
+            .ifPresent { catalog ->
+                val head = "package org.eclipse.edc.plugins.edcbuild;\npublic interface Versions {\n"
+                val tail = "\n}";
 
-            Files.writeString(folder.resolve("Versions.java").toPath(), constants)
-        }
+                val constants = listOf("jupiter", "mockito", "assertj")
+                    .mapNotNull { name ->
+                        catalog.findVersion(name)
+                            .map { version -> "    String %s = \"%s\";".format(name.toUpperCase(), version) }
+                            .orElse(null)
+                    }
+                    .joinToString("\n", head, tail)
+
+                Files.writeString(versionsClassFile.toPath(), constants)
+            }
+    }
+
 }
 
 tasks.compileJava {


### PR DESCRIPTION
## What this PR changes/adds

Add missing task `output` and move the logic into the `doLast` block 

## Why it does that

fix release

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
