### PR TITLE
build: set source dir relative to the module path

### DIFF
--- a/plugins/edc-build/build.gradle.kts
+++ b/plugins/edc-build/build.gradle.kts
@@ -49,7 +49,8 @@ gradlePlugin {
 sourceSets {
     main {
         java {
-            srcDir(rootDir.resolve("buildSrc").resolve("build").resolve("generated").resolve("sources"))
+            val rootProjectDir = projectDir.resolve("..").resolve("..")
+            srcDir(rootProjectDir.resolve("buildSrc").resolve("build").resolve("generated").resolve("sources"))
         }
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Sets additional source path relative to the module.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
