### PR TITLE
build: make default checkstyle version be updated by dependabot

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -25,27 +25,33 @@ maven/mavencentral/com.github.java-json-tools/json-schema-validator/2.2.8, Apach
 maven/mavencentral/com.google.code.findbugs/jsr305/2.0.1, BSD-3-Clause AND CC-BY-2.5 AND LGPL-2.1+, approved, CQ13390
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.1, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
+maven/mavencentral/com.google.collections/google-collections/1.0, Apache-2.0, approved, CQ3285
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.18.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.7.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/16.0.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/27.0.1-android, Apache-2.0, approved, CQ18308
 maven/mavencentral/com.google.guava/guava/31.0.1-jre, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.guava/guava/32.0.1-jre, Apache-2.0 AND CC0-1.0 AND CC-PDDC, approved, #8772
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.j2objc/j2objc-annotations/1.1, Apache-2.0, approved, CQ18765
 maven/mavencentral/com.google.j2objc/j2objc-annotations/1.3, Apache-2.0, approved, CQ21195
+maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.googlecode.libphonenumber/libphonenumber/8.0.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.0, LGPL-2.1-or-later, approved, #7936
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.12.3, LGPL-2.1+, restricted, clearlydefined
 maven/mavencentral/com.rameshkp/openapi-merger-app/1.0.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.rameshkp/openapi-merger-gradle-plugin/1.0.5, Apache-2.0, approved, #9669
 maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
+maven/mavencentral/commons-codec/commons-codec/1.11, Apache-2.0 AND BSD-3-Clause, approved, CQ15971
+maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
 maven/mavencentral/commons-codec/commons-codec/1.9, Apache-2.0, approved, CQ10595
 maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
 maven/mavencentral/commons-io/commons-io/2.4, Apache-1.1, approved, CQ9218
 maven/mavencentral/commons-io/commons-io/2.6, Apache-2.0, approved, CQ19090
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/gradle.plugin.org.gradle.crypto/checksum/1.4.0, Apache-2.0, approved, #9667
-maven/mavencentral/info.picocli/picocli/4.6.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/info.picocli/picocli/4.7.4, Apache-2.0, approved, #4365
 maven/mavencentral/io.github.gradle-nexus/publish-plugin/1.3.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause AND CPL-1.0 AND LGPL-2.1-only AND LGPL-2.1-or-later AND MIT AND LicenseRef-Permission-Notice), approved, #10359
 maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.1.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-core/2.1.5, Apache-2.0, approved, clearlydefined
@@ -74,19 +80,38 @@ maven/mavencentral/joda-time/joda-time/2.9.7, Apache-2.0, approved, CQ11988
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.11, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.3, MIT, approved, CQ13174
-maven/mavencentral/net.sf.saxon/Saxon-HE/10.6, MPL-2.0 AND W3C, approved, #7945
+maven/mavencentral/net.sf.saxon/Saxon-HE/12.3, NOASSERTION, restricted, clearlydefined
 maven/mavencentral/net.steppschuh.markdowngenerator/markdowngenerator/1.3.1.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.antlr/antlr4-runtime/4.9.3, BSD-3-Clause, approved, #322
+maven/mavencentral/org.antlr/antlr4-runtime/4.11.1, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.7, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-lang3/3.8.1, Apache-2.0, approved, #815
+maven/mavencentral/org.apache.commons/commons-text/1.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.httpcomponents.client5/httpclient5/5.1.3, Apache-2.0, approved, #6276
+maven/mavencentral/org.apache.httpcomponents.core5/httpcore5-h2/5.1.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.httpcomponents.core5/httpcore5/5.1.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.13, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ23527
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.2, Apache-2.0, approved, CQ11713
+maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.13, Apache-2.0, approved, CQ23528
+maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.14, Apache-2.0, approved, CQ23528
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.4, Apache-2.0, approved, CQ11716
+maven/mavencentral/org.apache.maven.doxia/doxia-core/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.maven.doxia/doxia-logging-api/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.maven.doxia/doxia-module-xdoc/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.maven.doxia/doxia-sink-api/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.25.1, Apache-2.0, approved, #12585
 maven/mavencentral/org.checkerframework/checker-compat-qual/2.5.2, GPL-2.0-only with Classpath-Exception-2.0, approved, #11598
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
+maven/mavencentral/org.checkerframework/checker-qual/3.27.0, MIT, approved, clearlydefined
 maven/mavencentral/org.codehaus.mojo/animal-sniffer-annotations/1.17, MIT, approved, clearlydefined
+maven/mavencentral/org.codehaus.plexus/plexus-classworlds/2.6.0, Apache-2.0 AND Plexus, approved, CQ22821
+maven/mavencentral/org.codehaus.plexus/plexus-component-annotations/2.1.0, Apache-2.0, approved, #809
+maven/mavencentral/org.codehaus.plexus/plexus-container-default/2.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.codehaus.plexus/plexus-utils/3.1.1, , approved, CQ16492
+maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.5.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.5.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.glassfish.web/javax.el/2.2.6, CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #1654
@@ -122,4 +147,5 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.25, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.28, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.30, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-ext/1.7.28, MIT, approved, CQ9128
+maven/mavencentral/org.xmlresolver/xmlresolver/5.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,18 +35,8 @@ allprojects {
         }
     }
 
-    // configure checkstyle version
     checkstyle {
-        toolVersion = "10.0"
         maxErrors = 0 // does not tolerate errors
-    }
-
-    // let's not generate any reports because that is done from within the Github Actions workflow
-    tasks.withType<Checkstyle> {
-        reports {
-            html.required.set(false)
-            xml.required.set(true)
-        }
     }
 
     tasks.withType<Jar> {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -41,7 +41,7 @@ gradlePlugin {
     }
 }
 
-val generatedSourcesFolder = buildDir.resolve("generated").resolve("sources");
+val generatedSourcesFolder = layout.buildDirectory.asFile.get().resolve("generated").resolve("sources");
 
 sourceSets {
     main {
@@ -74,10 +74,10 @@ val createVersions = tasks.register("createVersions") {
                 val head = "package org.eclipse.edc.plugins.edcbuild;\npublic interface Versions {\n"
                 val tail = "\n}";
 
-                val constants = listOf("jupiter", "mockito", "assertj")
+                val constants = listOf("assertj", "checkstyle", "jupiter", "mockito")
                     .mapNotNull { name ->
                         catalog.findVersion(name)
-                            .map { version -> "    String %s = \"%s\";".format(name.toUpperCase(), version) }
+                            .map { version -> "    String %s = \"%s\";".format(name.uppercase(), version) }
                             .orElse(null)
                     }
                     .joinToString("\n", head, tail)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ format.version = "1.1"
 
 [versions]
 assertj = "3.25.1"
-checkstyle = "10.12.0"
+checkstyle = "10.12.3"
 edc = "0.5.1-SNAPSHOT"
 jackson = "2.16.0"
 jetbrainsAnnotation = "24.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ format.version = "1.1"
 
 [versions]
 assertj = "3.25.1"
+checkstyle = "10.12.0"
 edc = "0.5.1-SNAPSHOT"
 jackson = "2.16.0"
 jetbrainsAnnotation = "24.0.1"
@@ -11,6 +12,7 @@ mockito = "5.9.0"
 
 [libraries]
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" }
 edc-runtime-metamodel = { module = "org.eclipse.edc:runtime-metamodel", version.ref = "edc" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/CheckstyleConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/CheckstyleConvention.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.plugins.edcbuild.conventions;
 
+import org.eclipse.edc.plugins.edcbuild.Versions;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.quality.Checkstyle;
 import org.gradle.api.plugins.quality.CheckstyleExtension;
@@ -30,13 +31,11 @@ import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.r
  */
 class CheckstyleConvention implements EdcConvention {
 
-    private static final String DEFAULT_TOOL_VERSION = "10.0";
-
     @Override
     public void apply(Project target) {
         var cse = requireExtension(target, CheckstyleExtension.class);
 
-        cse.setToolVersion(DEFAULT_TOOL_VERSION);
+        cse.setToolVersion(Versions.CHECKSTYLE);
         cse.setMaxErrors(0);
         target.getTasks().withType(Checkstyle.class, cs -> cs.reports(r -> {
             r.getHtml().getRequired().set(false);


### PR DESCRIPTION
## What this PR changes/adds

Currently is not possible to let the `edc-build` plugin use the latest checkstyle version by default.
This PR adds `checkstyle` dependency on the version catalog and put the version as the default version set by the `CheckstyleConvention`. This way, when not overrode, it will take the one in the catalog, that, thanks to dependabot, will supposedly updated to the latest one.

## Why it does that

version updates

## Further notes

- looks like in the last version of checkstyle there are issues with guava (that's a dependency): https://github.com/google/guava/issues/6825 so I set the checkstyle version to the latest working one

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
