### PR TITLE
feat: set checkstyle max warnings 0 by default

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -39,7 +39,7 @@ maven/mavencentral/com.google.j2objc/j2objc-annotations/1.1, Apache-2.0, approve
 maven/mavencentral/com.google.j2objc/j2objc-annotations/1.3, Apache-2.0, approved, CQ21195
 maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.googlecode.libphonenumber/libphonenumber/8.0.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.12.3, LGPL-2.1+, restricted, clearlydefined
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.12.3, LGPL-2.1-only AND Apache-2.0 AND LGPL-2.1-or-later AND ANTLR-PD AND GPL-2.0-or-later AND LGPL-2.0-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND LicenseRef-scancode-proprietary-license, restricted, #13190
 maven/mavencentral/com.rameshkp/openapi-merger-app/1.0.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.rameshkp/openapi-merger-gradle-plugin/1.0.5, Apache-2.0, approved, #9669
 maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
@@ -80,7 +80,7 @@ maven/mavencentral/joda-time/joda-time/2.9.7, Apache-2.0, approved, CQ11988
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.11, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.3, MIT, approved, CQ13174
-maven/mavencentral/net.sf.saxon/Saxon-HE/12.3, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/net.sf.saxon/Saxon-HE/12.3, MPL-2.0-no-copyleft-exception AND (LicenseRef-scancode-proprietary-license AND MPL-2.0-no-copyleft-exception) AND (MPL-2.0-no-copyleft-exception AND X11) AND (MIT AND MPL-2.0-no-copyleft-exception) AND (MPL-1.0 AND MPL-2.0-no-copyleft-exception) AND (Apache-2.0 AND MPL-2.0-no-copyleft-exception) AND MPL-1.0, restricted, #13191
 maven/mavencentral/net.steppschuh.markdowngenerator/markdowngenerator/1.3.1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.antlr/antlr4-runtime/4.11.1, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
@@ -112,8 +112,8 @@ maven/mavencentral/org.codehaus.plexus/plexus-component-annotations/2.1.0, Apach
 maven/mavencentral/org.codehaus.plexus/plexus-container-default/2.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.codehaus.plexus/plexus-utils/3.1.1, , approved, CQ16492
 maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
-maven/mavencentral/org.eclipse.edc/autodoc-processor/0.5.1-SNAPSHOT, Apache-2.0, approved, technology.edc
-maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.5.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/autodoc-processor/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.5.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.glassfish.web/javax.el/2.2.6, CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #1654
 maven/mavencentral/org.hibernate.validator/hibernate-validator-annotation-processor/6.0.2.Final, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ20221
 maven/mavencentral/org.hibernate.validator/hibernate-validator/6.0.2.Final, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ15540

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,4 +1,5 @@
 import java.nio.file.Files
+import java.time.LocalDateTime
 
 plugins {
     `java-gradle-plugin`
@@ -71,7 +72,23 @@ val createVersions = tasks.register("createVersions") {
     doLast {
         versionCatalogs.find("libs")
             .ifPresent { catalog ->
-                val head = "package org.eclipse.edc.plugins.edcbuild;\npublic interface Versions {\n"
+                val copyright = """
+                    /*
+                     *  Copyright (c) ${LocalDateTime.now().year} Contributors to the Eclipse Foundation
+                     *
+                     *  This program and the accompanying materials are made available under the
+                     *  terms of the Apache License, Version 2.0 which is available at
+                     *  https://www.apache.org/licenses/LICENSE-2.0
+                     *
+                     *  SPDX-License-Identifier: Apache-2.0
+                     *
+                     *  Contributors:
+                     *       Contributors to the Eclipse Foundation - initial API and implementation
+                     *
+                     */
+                """.trimIndent()
+
+                val head = "$copyright\n\npackage org.eclipse.edc.plugins.edcbuild;\npublic interface Versions {\n"
                 val tail = "\n}";
 
                 val constants = listOf("assertj", "checkstyle", "jupiter", "mockito")

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -50,8 +50,7 @@
     <module name="RegexpHeader">
         <property name="severity" value="warning"/>
         <property name="fileExtensions" value="java"/>
-        <property name="header"
-                  value="^/\*$\n^ \*  Copyright \(c\) 20\d\d((,| -) 20\d{2})? [A-Za-z].+\S$\n^ \*$\n^ \*  This program and the accompanying materials are made available under the$\n^ \*  terms of the Apache License, Version 2\.0 which is available at$\n^ \*  https://www\.apache\.org/licenses/LICENSE-2\.0$\n^ \*$\n^ \*  SPDX-License-Identifier: Apache-2\.0$\n^ \*$\n^ \*  Contributors:$\n^ \*       \S.*\S$\n^ \*$\n^ \*/$\n^$\n^package"/>
+        <property name="headerFile" value="${config_loc}/java.header"/>
         <property name="multiLines" value="11"/>
     </module>
 

--- a/config/checkstyle/java.header
+++ b/config/checkstyle/java.header
@@ -1,0 +1,15 @@
+^/\*$
+^ \*  Copyright \(c\) 20\d\d((,| -) 20\d{2})? [A-Za-z].+\S$
+^ \*$
+^ \*  This program and the accompanying materials are made available under the$
+^ \*  terms of the Apache License, Version 2\.0 which is available at$
+^ \*  https://www\.apache\.org/licenses/LICENSE-2\.0$
+^ \*$
+^ \*  SPDX-License-Identifier: Apache-2\.0$
+^ \*$
+^ \*  Contributors:$
+^ \*       \S.*\S$
+^ \*$
+^ \*/$
+^$
+^package

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
@@ -1,13 +1,13 @@
 /*
- * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
  *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Contributors:
+ *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *
  */

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/CheckstyleConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/CheckstyleConvention.java
@@ -33,11 +33,13 @@ class CheckstyleConvention implements EdcConvention {
 
     @Override
     public void apply(Project target) {
-        var cse = requireExtension(target, CheckstyleExtension.class);
+        var extension = requireExtension(target, CheckstyleExtension.class);
 
-        cse.setToolVersion(Versions.CHECKSTYLE);
-        cse.setMaxErrors(0);
-        target.getTasks().withType(Checkstyle.class, cs -> cs.reports(r -> {
+        extension.setToolVersion(Versions.CHECKSTYLE);
+        extension.setMaxErrors(0);
+        extension.setMaxWarnings(0);
+
+        target.getTasks().withType(Checkstyle.class, checkstyle -> checkstyle.reports(r -> {
             r.getHtml().getRequired().set(false);
             r.getXml().getRequired().set(true);
         }));


### PR DESCRIPTION
## What this PR changes/adds

Currently the `checkstyle` plugin permits warnings, but that's not ok (in fact currently there are two warns logged into the console, which I fixed in this PR).

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
