### PR TITLE
feat: make edc-build register printClasspath plugin

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/EdcBuildPlugin.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/EdcBuildPlugin.java
@@ -30,6 +30,7 @@ import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.mavenPom;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.mavenPublication;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.mavenPublishing;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.nexusPublishing;
+import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.printClasspath;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.repositories;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.rootBuildScript;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.signing;
@@ -74,7 +75,8 @@ public class EdcBuildPlugin implements Plugin<Project> {
                     allDependencies(),
                     tests(),
                     jar(),
-                    swagger()
+                    swagger(),
+                    printClasspath()
             ).forEach(c -> c.apply(project));
         });
 

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/Conventions.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/Conventions.java
@@ -23,7 +23,6 @@ public class Conventions {
         return new CheckstyleConvention();
     }
 
-
     public static EdcConvention mavenPublishing() {
         return new MavenPublishingConvention();
     }
@@ -86,5 +85,9 @@ public class Conventions {
     
     public static EdcConvention mavenPublication() {
         return new MavenPublicationConvention();
+    }
+
+    public static EdcConvention printClasspath() {
+        return new PrintClasspathConvention();
     }
 }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/PrintClasspathConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/PrintClasspathConvention.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.edcbuild.conventions;
+
+import org.eclipse.edc.plugins.edcbuild.tasks.PrintClasspathTask;
+import org.gradle.api.Project;
+
+public class PrintClasspathConvention implements EdcConvention {
+    @Override
+    public void apply(Project target) {
+        target.getTasks().register("printClasspath", PrintClasspathTask.class)
+                .configure(t -> t.dependsOn("compileJava"));
+    }
+}

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/tasks/PrintClasspathTask.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/tasks/PrintClasspathTask.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.edcbuild.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.TaskAction;
+
+import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.requireExtension;
+
+
+public class PrintClasspathTask extends DefaultTask {
+
+    @TaskAction
+    public void printClasspath() {
+        var classpath = requireExtension(getProject(), JavaPluginExtension.class)
+                .getSourceSets()
+                .getByName("main")
+                .getRuntimeClasspath()
+                .getAsPath();
+
+        System.out.println(classpath);
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

registers the `printClasspath` task for every project that applies `edc-build` plugin

## Why it does that

avoid duplication

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #230

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
