### PR TITLE
build: make swagger be upgraded by dependabot

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,9 +1,7 @@
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.11.1, Apache-2.0, approved, CQ23491
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.0, Apache-2.0, approved, #13672
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.1, Apache-2.0, approved, #13672
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.1, , approved, #13665
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.11.1, Apache-2.0, approved, CQ23093
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.0, Apache-2.0, approved, #13671
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.1, Apache-2.0, approved, #13671
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.2.3, Apache-2.0, approved, #10357
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.11.1, Apache-2.0, approved, CQ23094
@@ -56,7 +54,7 @@ maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approv
 maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, approved, #11683
 maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.1.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-core/2.1.5, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-gradle-plugin/2.2.15, Apache-2.0 AND MIT, approved, #10356
+maven/mavencentral/io.swagger.core.v3/swagger-gradle-plugin/2.2.21, Apache-2.0 AND MIT, approved, #10356
 maven/mavencentral/io.swagger.core.v3/swagger-models/2.1.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.parser.v3/swagger-parser-core/2.0.23, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.parser.v3/swagger-parser-v2-converter/2.0.23, Apache-2.0, approved, clearlydefined
@@ -85,7 +83,7 @@ maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.3, MIT, approved, CQ13174
 maven/mavencentral/net.sf.saxon/Saxon-HE/12.4, MPL-2.0 AND (MPL-2.0 AND Apache-2.0) AND (MPL-2.0 AND LicenseRef-X11-style) AND MPL-1.0 AND W3C, approved, #12716
 maven/mavencentral/net.steppschuh.markdowngenerator/markdowngenerator/1.3.1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.antlr/antlr4-runtime/4.13.1, BSD-3-Clause, approved, #10767
-maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-lang3/3.14.0, Apache-2.0, approved, #11677
 maven/mavencentral/org.apache.commons/commons-lang3/3.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.8.1, Apache-2.0, approved, #815

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -90,10 +90,11 @@ val createVersions = tasks.register("createVersions") {
                 val head = "$copyright\n\npackage org.eclipse.edc.plugins.edcbuild;\npublic interface Versions {\n"
                 val tail = "\n}";
 
-                val constants = listOf("assertj", "checkstyle", "jupiter", "mockito")
+                val constants = listOf("assertj", "checkstyle", "jakarta-ws-rs", "jupiter", "mockito", "swagger")
                     .mapNotNull { name ->
+                        val constantName = name.uppercase().replace("-", "_")
                         catalog.findVersion(name)
-                            .map { version -> "    String %s = \"%s\";".format(name.uppercase(), version) }
+                            .map { version -> "    String %s = \"%s\";".format(constantName, version) }
                             .orElse(null)
                     }
                     .joinToString("\n", head, tail)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,8 +7,10 @@ checkstyle = "10.16.0"
 edc = "0.6.4-SNAPSHOT"
 jackson = "2.17.1"
 jetbrainsAnnotation = "24.0.1"
+jakarta-ws-rs = "3.1.0"
 jupiter = "5.10.1"
 mockito = "5.11.0"
+swagger = "2.2.21"
 
 [libraries]
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
@@ -17,6 +19,7 @@ edc-runtime-metamodel = { module = "org.eclipse.edc:runtime-metamodel", version.
 edc-core-spi = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jakarta-ws-rs-api = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "jakarta-ws-rs" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotation" }
 jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jupiter" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
@@ -24,7 +27,7 @@ plugin-checksum = { module = "gradle.plugin.org.gradle.crypto:checksum", version
 plugin-nexus-publish = { module = "io.github.gradle-nexus:publish-plugin", version = "1.3.0" }
 plugin-openapi-merger = { module = "com.rameshkp:openapi-merger-gradle-plugin", version = "1.0.5" }
 plugin-openapi-merger-app = { module = "com.rameshkp:openapi-merger-app", version = "1.0.5" }
-plugin-swagger = { module = "io.swagger.core.v3:swagger-gradle-plugin", version = "2.2.15" }
+plugin-swagger = { module = "io.swagger.core.v3:swagger-gradle-plugin", version.ref = "swagger" }
 
 # third party
 j2html = { module = "com.j2html:j2html", version = "1.6.0" }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/SwaggerResolveConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/SwaggerResolveConvention.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.plugins.edcbuild.conventions;
 
 import io.swagger.v3.plugins.gradle.tasks.ResolveTask;
+import org.eclipse.edc.plugins.edcbuild.Versions;
 import org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension;
 import org.eclipse.edc.plugins.edcbuild.tasks.PrintApiGroupTask;
 import org.gradle.api.Project;
@@ -22,6 +23,7 @@ import org.gradle.api.plugins.JavaPluginExtension;
 
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.requireExtension;
 import static org.eclipse.edc.plugins.edcbuild.conventions.SwaggerConvention.defaultOutputDirectory;
@@ -33,15 +35,18 @@ import static org.gradle.api.plugins.JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAM
 class SwaggerResolveConvention implements EdcConvention {
 
     private static final String DEFAULT_API_GROUP = "";
+    public static final String SWAGGER_GRADLE_PLUGIN = "io.swagger.core.v3.swagger-gradle-plugin";
 
     @Override
     public void apply(Project target) {
-        target.getPluginManager().withPlugin("io.swagger.core.v3.swagger-gradle-plugin", appliedPlugin -> {
+        target.getPluginManager().withPlugin(SWAGGER_GRADLE_PLUGIN, appliedPlugin -> {
 
             target.getTasks().register("apiGroups", PrintApiGroupTask.class);
 
-            target.getDependencies().add(IMPLEMENTATION_CONFIGURATION_NAME, "io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.15");
-            target.getDependencies().add(IMPLEMENTATION_CONFIGURATION_NAME, "jakarta.ws.rs:jakarta.ws.rs-api:3.1.0");
+            Stream.of(
+                    "io.swagger.core.v3:swagger-jaxrs2-jakarta:%s".formatted(Versions.SWAGGER),
+                    "jakarta.ws.rs:jakarta.ws.rs-api:%s".formatted(Versions.JAKARTA_WS_RS)
+            ).forEach(dependency -> target.getDependencies().add(IMPLEMENTATION_CONFIGURATION_NAME, dependency));
 
             var javaExt = requireExtension(target, JavaPluginExtension.class);
             var swaggerExt = requireExtension(target, BuildExtension.class).getSwagger();

--- a/plugins/edc-build/src/test/java/org/eclipse/edc/plugins/edcbuild/conventions/SwaggerResolveConventionTest.java
+++ b/plugins/edc-build/src/test/java/org/eclipse/edc/plugins/edcbuild/conventions/SwaggerResolveConventionTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.plugins.edcbuild.conventions.SwaggerResolveConvention.SWAGGER_GRADLE_PLUGIN;
 
 class SwaggerResolveConventionTest {
 
@@ -34,7 +35,7 @@ class SwaggerResolveConventionTest {
     @BeforeEach
     void setUp() {
         project = ProjectBuilder.builder().withName(PROJECT_NAME).build();
-        project.getPluginManager().apply("io.swagger.core.v3.swagger-gradle-plugin");
+        project.getPluginManager().apply(SWAGGER_GRADLE_PLUGIN);
         project.getPluginManager().apply(JavaPlugin.class);
         project.getExtensions().create("edcBuild", BuildExtension.class, project.getObjects());
     }


### PR DESCRIPTION
## What this PR changes/adds

Make dependabot take care of swagger plugin version

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #236 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
