### PR TITLE
feat: publish openapi spec as artifact

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -12,11 +12,11 @@ maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.17.1, Apache-2.0, approve
 maven/mavencentral/com.fasterxml/classmate/1.3.1, Apache-2.0, approved, CQ10239
 maven/mavencentral/com.github.fge/btf/1.2, Apache-2.0 OR LGPL-2.0-or-later, approved, CQ14455
 maven/mavencentral/com.github.fge/jackson-coreutils/1.6, Apache-2.0 or LGPL-3.0-only, approved, #2572
-maven/mavencentral/com.github.fge/jackson-coreutils/1.8, LGPL-3.0 OR Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.github.fge/jackson-coreutils/1.8, (Apache-2.0 AND LGPL-3.0 AND LGPL-3.0-only) OR (Apache-2.0 AND LGPL-3.0-only), restricted, clearlydefined
 maven/mavencentral/com.github.fge/json-patch/1.6, Apache-2.0 OR LGPL-3.0-or-later, approved, #10358
 maven/mavencentral/com.github.fge/msg-simple/1.1, Apache-2.0 OR LGPL-3.0-or-later, approved, #2574
 maven/mavencentral/com.github.fge/uri-template/0.9, Apache-2.0 OR LGPL-3.0-or-later, approved, #9668
-maven/mavencentral/com.github.java-json-tools/json-schema-core/1.2.8, Apache-2.0 AND LGPL-2.1-or-later AND LGPL-3.0-only AND (Apache-2.0 AND GPL-1.0-or-later AND LGPL-3.0-only) AND Apache-2.0 AND LGPL-3.0-only, restricted, #15282
+maven/mavencentral/com.github.java-json-tools/json-schema-core/1.2.8, Apache-2.0 OR LGPL-3.0-or-later, approved, #15282
 maven/mavencentral/com.github.java-json-tools/json-schema-validator/2.2.8, Apache-2.0 OR LGPL-3.0-or-later, approved, CQ20779
 maven/mavencentral/com.google.code.findbugs/jsr305/2.0.1, BSD-3-Clause AND CC-BY-2.5 AND LGPL-2.1+, approved, CQ13390
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.1, CC-BY-2.5, approved, #15220
@@ -54,7 +54,7 @@ maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approv
 maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, approved, #11683
 maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.1.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-core/2.1.5, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.swagger.core.v3/swagger-gradle-plugin/2.2.21, Apache-2.0 AND MIT, approved, #10356
+maven/mavencentral/io.swagger.core.v3/swagger-gradle-plugin/2.2.22, Apache-2.0 AND MIT, approved, #10356
 maven/mavencentral/io.swagger.core.v3/swagger-models/2.1.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.parser.v3/swagger-parser-core/2.0.23, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.parser.v3/swagger-parser-v2-converter/2.0.23, Apache-2.0, approved, clearlydefined

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ jetbrainsAnnotation = "24.0.1"
 jakarta-ws-rs = "4.0.0"
 jupiter = "5.10.1"
 mockito = "5.12.0"
-swagger = "2.2.21"
+swagger = "2.2.22"
 
 [libraries]
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocDependencyInjector.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocDependencyInjector.java
@@ -51,13 +51,12 @@ class AutodocDependencyInjector implements DependencyResolutionListener {
             project.getLogger().debug("{}: use configured version from AutodocExtension (override) [{}]", project.getName(), version);
         } else {
             artifact += ":+";
-            project.getLogger().warn("No explicit configuration value for the annotationProcessor version was found. Please supply a configuration for the Autodoc Plugin's annotationProcessor.");
+            project.getLogger().info("No explicit configuration value for the annotationProcessor version was found. Current one will be used");
         }
 
         if (addDependency(project, artifact)) {
             var task = project.getTasks().findByName("compileJava");
-            if ((task instanceof JavaCompile)) {
-                var compileJava = (JavaCompile) task;
+            if ((task instanceof JavaCompile compileJava)) {
                 var versionArg = format("-A%s=%s", VERSION, project.getVersion());
                 var idArg = format("-A%s=%s:%s", ID, project.getGroup(), project.getName());
                 var outputArg = format("-A%s=%s", OUTPUTDIR, extension.getOutputDirectory().getOrNull());

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocExtension.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocExtension.java
@@ -22,7 +22,8 @@ public abstract class AutodocExtension {
     private boolean includeTransitive = true;
 
     /**
-     * Overrides the default output directory relative to the current project dir
+     * Overrides the default output directory relative to the current project dir.
+     * By default, it is the "build" directory.
      */
     public abstract Property<File> getOutputDirectory();
 


### PR DESCRIPTION
## What this PR changes/adds

Adds an `openapi` task, that generates the openapi spec file for a project that has the swagger plugin registered and publishes it as a maven artifact

## Why it does that

documentation.

## Further notes

at this point a new "merge" task that merges the files from the subprojects build folders instead of the `resources` ones could be implemented (as it was done in `MergeManifestTask`)

## Linked Issue(s)

Closes #244 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
