### PR TITLE
refactor: publish openapi artifact with api group as classifier

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/SwaggerResolveConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/SwaggerResolveConvention.java
@@ -56,8 +56,8 @@ class SwaggerResolveConvention implements EdcConvention {
 
             target.getTasks().withType(ResolveTask.class, task -> {
                 var outputFileName = swaggerExt.getOutputFilename().getOrElse(target.getName());
-                var apiGroup = swaggerExt.getApiGroup().getOrElse(DEFAULT_API_GROUP);
                 var fallbackOutputDir = defaultOutputDirectory(target);
+                var apiGroup = swaggerExt.getApiGroup().getOrElse(DEFAULT_API_GROUP);
 
                 var outputDir = Path.of(swaggerExt.getOutputDirectory().getOrElse(fallbackOutputDir.toFile()).toURI())
                         .resolve(apiGroup)
@@ -81,7 +81,7 @@ class SwaggerResolveConvention implements EdcConvention {
                 target.getTasks().findByName("jar").dependsOn(task);
                 task.setGroup("documentation");
                 task.setDescription("Generates openapi specification documentation.");
-                task.setOutputFileName("openapi");
+                task.setOutputFileName(swaggerExt.getApiGroup().getOrElse("openapi"));
                 task.setOutputDir(outputDir);
                 task.setOutputFormat(ResolveTask.Format.YAML);
                 task.setSortOutput(true);


### PR DESCRIPTION
## What this PR changes/adds

Publish the openapi artifact with the `apiGroup` as classifier when specified.

## Why it does that

It will be easier for downstream project to filter/group specs by apiGroup

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Part of #244 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
