### PR TITLE
feat: render deprecated setting as strikethrough

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -116,6 +116,7 @@ maven/mavencentral/org.eclipse.edc/autodoc-processor/+, Apache-2.0, approved, te
 maven/mavencentral/org.eclipse.edc/boot-spi/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/core-spi/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/policy-model/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.8.2-20240808-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/runtime-metamodel/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.glassfish.web/javax.el/2.2.6, CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #1654
 maven/mavencentral/org.hibernate.validator/hibernate-validator-annotation-processor/6.0.2.Final, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ20221

--- a/plugins/autodoc/autodoc-converters/src/main/resources/style.css
+++ b/plugins/autodoc/autodoc-converters/src/main/resources/style.css
@@ -1,0 +1,35 @@
+* {
+  box-sizing: border-box;
+}
+nav {
+  float: left;
+  width: 20%;
+  padding: 20px;
+}
+article {
+  float: left;
+  padding: 20px;
+  width: 80%;
+}
+table {
+  margin: 1em 0;
+  border-collapse: collapse;
+  width: 100%;
+  overflow-x: auto;
+  display: block;
+  font-variant-numeric: lining-nums tabular-nums;
+}
+tbody {
+  margin-top: 0.5em;
+  border-top: 1px solid #1a1a1a;
+  border-bottom: 1px solid #1a1a1a;
+}
+td {
+  padding: 5px
+}
+.odd {
+  background-color: cccccc;
+}
+.even {
+  background-color: eeeeee;
+}

--- a/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/html/HtmlManifestRendererTest.java
+++ b/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/html/HtmlManifestRendererTest.java
@@ -173,6 +173,21 @@ public class HtmlManifestRendererTest {
                     .contains("<table>", "<thead>", "<tbody>", "<tr>", "<td>")
                     .contains("<td><code>edc.setting.path</code></td>");
         }
+
+        @Test
+        void shouldRenderDeprecatedConfiguration() {
+            var setting = ConfigurationSetting.Builder.newInstance()
+                    .key("edc.setting.path")
+                    .deprecated(true)
+                    .build();
+            renderer.renderConfigurations(List.of(setting));
+
+            var output = renderer.finalizeRendering();
+
+            assertThat(output).asString()
+                    .contains("<table>", "<thead>", "<tbody>", "<tr>", "<td>")
+                    .contains("<td><s><code>edc.setting.path</code></s></td>");
+        }
     }
 
     @Nested

--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ExtensionIntrospector.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ExtensionIntrospector.java
@@ -148,6 +148,7 @@ public class ExtensionIntrospector {
                 .maximum(attributeValue(Long.class, "max", settingMirror, elementUtils))
                 .minimum(attributeValue(Long.class, "min", settingMirror, elementUtils))
                 .defaultValue(attributeValue(String.class, "defaultValue", settingMirror, elementUtils))
+                .deprecated(mirrorFor(Deprecated.class, settingElement) != null)
                 .build();
     }
 

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/Constants.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/Constants.java
@@ -18,6 +18,7 @@ public interface Constants {
     String TEST_SETTING_NAME = "Test setting name";
     String TEST_SETTING_KEY = "edc.test.setting";
     String TEST_SETTING_DEFAULT_VALUE = "default value";
+    String TEST_DEPRECATED_SETTING_KEY = "edc.test.deprecated.setting";
     String TEST_SPI_MODULE = "Test SPI Module";
 
     String TEST_FIELD_PREFIX_SETTING_KEY = "edc.prefix.field.";

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testextensions/SampleExtensionWithoutAnnotation.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testextensions/SampleExtensionWithoutAnnotation.java
@@ -28,6 +28,10 @@ public class SampleExtensionWithoutAnnotation implements ServiceExtension {
     @Setting(value = Constants.TEST_SETTING_NAME, required = true, defaultValue = TEST_SETTING_DEFAULT_VALUE)
     public static final String TEST_SETTING = Constants.TEST_SETTING_KEY;
 
+    @Deprecated(since = "forever")
+    @Setting(value = "deprecated")
+    public static final String DEPRECATED_TEST_SETTING = Constants.TEST_DEPRECATED_SETTING_KEY;
+
     @Inject
     protected RequiredService requiredService;
 


### PR DESCRIPTION
## What this PR changes/adds

Render `@Deprecated` setting as ~~strikethrough~~ in autodoc output

## Why it does that

documentation

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #251 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
