### PR TITLE
feat: permit to set spec version with property

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/SwaggerGeneratorExtension.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/SwaggerGeneratorExtension.java
@@ -22,9 +22,6 @@ import java.util.Set;
 public abstract class SwaggerGeneratorExtension {
 
     private Set<String> resourcePackages = Set.of("org.eclipse.edc");
-    private String mergedFileName = "openapi";
-    private String mergedFileExtension = "yaml";
-    private String description = "All files merged by open api merger";
 
     public abstract Property<String> getOutputFilename();
 
@@ -46,37 +43,7 @@ public abstract class SwaggerGeneratorExtension {
     /**
      * OpenAPI description of the merged openapi.yaml file
      */
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    /**
-     * File name of the file into which all the openapi files of all the modules are merged.
-     * Defaults to "openapi"
-     */
-    public String getMergedFileName() {
-        return mergedFileName;
-    }
-
-    public void setMergedFileName(String mergedFileName) {
-        this.mergedFileName = mergedFileName;
-    }
-
-    /**
-     * File extension of the file into which all the openapi files of all the modules are merged.
-     * Defaults to "yaml"
-     */
-    public String getMergedFileExtension() {
-        return mergedFileExtension;
-    }
-
-    public void setMergedFileExtension(String mergedFileExtension) {
-        this.mergedFileExtension = mergedFileExtension;
-    }
+    public abstract Property<String> getDescription();
 
     public abstract Property<String> getApiGroup();
 


### PR DESCRIPTION
## What this PR changes/adds

Permits to set the openapi spec version with an `apiVersion` properties. 

## Why it does that

currently it is not possible and it was necessary to set the whole project version, but spec and project version are (/should be) two completely different values.

## Further notes

- uniform the way with which it's possible to customize the api spec by reading also `apiTitle` and `apiDescription` that are currently evaluated in the single repo build files. 
- removed unused extension methods

## Linked Issue(s)

Closes #256 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
