### PR TITLE
fix: avoid 'example: null' entries in openapi by compel swagger-parser version

### DIFF
--- a/.github/workflows/discord-webhook.yml
+++ b/.github/workflows/discord-webhook.yml
@@ -23,4 +23,4 @@ jobs:
       event_sender_login: ${{ github.event.sender.login }}
       repository_name: ${{ github.repository }}
     secrets:
-      env_discord: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+      env_discord: ${{ secrets.DISCORD_GITHUB_WEBHOOK }}

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,6 @@
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.11.1, Apache-2.0, approved, CQ23491
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.17.2, Apache-2.0, approved, #13672
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.11.1, Apache-2.0, approved, CQ23092
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.2, , approved, #13665
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.11.1, Apache-2.0, approved, CQ23093
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.2, Apache-2.0, approved, #13671
@@ -35,7 +36,7 @@ maven/mavencentral/com.google.j2objc/j2objc-annotations/1.1, Apache-2.0, approve
 maven/mavencentral/com.google.j2objc/j2objc-annotations/1.3, Apache-2.0, approved, CQ21195
 maven/mavencentral/com.googlecode.libphonenumber/libphonenumber/8.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.j2html/j2html/1.6.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.18.1, LGPL-2.1-or-later, restricted, clearlydefined
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.18.1, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #16060
 maven/mavencentral/com.rameshkp/openapi-merger-app/1.0.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.rameshkp/openapi-merger-gradle-plugin/1.0.5, Apache-2.0, approved, #9669
 maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
@@ -80,7 +81,7 @@ maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.15.0, Apache-2.0, approved, 
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.18, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.15.0, Apache-2.0 AND BSD-3-Clause, approved, #16008
 maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.3, MIT, approved, CQ13174
-maven/mavencentral/net.sf.saxon/Saxon-HE/12.5, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/net.sf.saxon/Saxon-HE/12.5, MPL-2.0-no-copyleft-exception AND (LicenseRef-scancode-proprietary-license AND MPL-2.0-no-copyleft-exception) AND (MPL-2.0-no-copyleft-exception AND X11) AND (MIT AND MPL-2.0-no-copyleft-exception) AND (MPL-1.0 AND MPL-2.0-no-copyleft-exception) AND (Apache-2.0 AND MPL-2.0-no-copyleft-exception) AND MPL-1.0, restricted, #16061
 maven/mavencentral/net.steppschuh.markdowngenerator/markdowngenerator/1.3.1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.antlr/antlr4-runtime/4.13.2, BSD-3-Clause, approved, #10767
 maven/mavencentral/org.apache.commons/commons-lang3/3.14.0, Apache-2.0, approved, #11677
@@ -132,7 +133,7 @@ maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.11.0, EPL-2.0, appro
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.11.0, EPL-2.0, approved, #15940
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.11.0, EPL-2.0, approved, #15936
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.11.0, EPL-2.0, approved, #15932
-maven/mavencentral/org.junit/junit-bom/5.11.0, , restricted, clearlydefined
+maven/mavencentral/org.junit/junit-bom/5.11.0, EPL-2.0, approved, #16062
 maven/mavencentral/org.mockito/mockito-core/5.13.0, MIT, approved, clearlydefined
 maven/mavencentral/org.mozilla/rhino/1.7R4, MPL-2.0 AND BSD-3-Clause AND ISC, approved, CQ16320
 maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
@@ -144,4 +145,5 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.28, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.30, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-ext/1.7.28, MIT, approved, CQ9128
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.yaml/snakeyaml/1.26, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,11 +17,16 @@ repositories {
 }
 
 dependencies {
+    constraints {
+        implementation(libs.swagger.parser) {
+            because("OpenAPI merger plugin uses an old version that caused this issue: https://github.com/eclipse-edc/GradlePlugins/issues/183")
+        }
+    }
+
     implementation(libs.plugin.nexus.publish)
     implementation(libs.plugin.checksum)
     implementation(libs.plugin.swagger)
     implementation(libs.plugin.openapi.merger)
-    implementation(libs.plugin.openapi.merger.app)
 
     implementation(libs.jetbrains.annotations)
     implementation(libs.jackson.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ jakarta-ws-rs = "4.0.0"
 jupiter = "5.11.0"
 mockito = "5.13.0"
 swagger = "2.2.22"
+swagger-parser = "2.1.22"
 
 [libraries]
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
@@ -28,8 +29,8 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 plugin-checksum = { module = "gradle.plugin.org.gradle.crypto:checksum", version = "1.4.0" }
 plugin-nexus-publish = { module = "io.github.gradle-nexus:publish-plugin", version = "2.0.0" }
 plugin-openapi-merger = { module = "com.rameshkp:openapi-merger-gradle-plugin", version = "1.0.5" }
-plugin-openapi-merger-app = { module = "com.rameshkp:openapi-merger-app", version = "1.0.5" }
 plugin-swagger = { module = "io.swagger.core.v3:swagger-gradle-plugin", version.ref = "swagger" }
+swagger-parser = { module = "io.swagger.parser.v3:swagger-parser", version.ref = "swagger-parser" }
 
 [bundles]
 

--- a/plugins/openapi-merger/build.gradle.kts
+++ b/plugins/openapi-merger/build.gradle.kts
@@ -5,13 +5,7 @@ plugins {
 val group: String by project
 
 dependencies {
-    // contains the actual merger task
     implementation(libs.plugin.openapi.merger)
-    // needed for the OpenApiDataInvalidException:
-    implementation(libs.plugin.openapi.merger.app)
-
-    implementation(libs.edc.runtime.metamodel)
-
 }
 
 gradlePlugin {


### PR DESCRIPTION
## What this PR changes/adds

Compel `swagger-parser` version to 2.1.12 because the old version caused `example: null` entries in the openapi files (that cause mis-rendering in the UI)

## Why it does that



## Further notes

- fixed typo in the discord webhook workflow

## Linked Issue(s)

Closes #183

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
