### PR TITLE
docs: improve markdown rendering

### DIFF
--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRenderer.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRenderer.java
@@ -55,21 +55,24 @@ public class MarkdownManifestRenderer implements ManifestRenderer {
 
     @Override
     public void renderDocumentHeader() {
-        stringBuilder.append(heading(DOCUMENT_HEADING, 1)).append(NEWLINE);
-        stringBuilder.append(NEWLINE);
+
     }
 
     @Override
     public void renderModuleHeading(@Nullable String moduleName, @NotNull String modulePath, @NotNull String version) {
-        var name = ofNullable(moduleName).orElse(modulePath);
+        var modulePathTokens = modulePath.split(":");
+        var artifactId = modulePathTokens.length == 2 ? modulePathTokens[1] : modulePath;
 
-        var moduleHeading = heading(format("Module `%s:%s`", name, version), 2);
+        var moduleHeading = heading(format("Module `%s`", artifactId), 2);
         stringBuilder.append(moduleHeading).append(NEWLINE);
 
         if (moduleName != null) {
-            stringBuilder.append(italic(modulePath)).append(NEWLINE);
+            stringBuilder.append(italic("name: ")).append(moduleName).append(NEWLINE);
         }
-        stringBuilder.append(NEWLINE);
+
+        stringBuilder
+                .append(italic("artifact: ")).append(modulePath).append(":").append(version).append(NEWLINE)
+                .append(NEWLINE);
     }
 
     @Override
@@ -122,7 +125,7 @@ public class MarkdownManifestRenderer implements ManifestRenderer {
                 .map(this::renderConfigurationSetting)
                 .forEach(tableBuilder::addRow);
 
-        stringBuilder.append(heading("Configuration: ", 5));
+        stringBuilder.append(heading("Configuration: ", 3));
         if (!configuration.isEmpty()) {
             stringBuilder.append(NEWLINE).append(NEWLINE).append(tableBuilder.build()).append(NEWLINE);
         } else {

--- a/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestRenderer.java
+++ b/plugins/autodoc/autodoc-converters/src/main/java/org/eclipse/edc/plugins/autodoc/spi/ManifestRenderer.java
@@ -29,7 +29,6 @@ import java.util.List;
  * The ManifestRenderer interface provides callback methods to render a manifest document.
  */
 public interface ManifestRenderer {
-    String DOCUMENT_HEADING = "EDC Autodoc Manifest";
     String EXTENSION_POINTS = "Extension points";
     String EXTENSIONS = "Extensions";
     String NONE = "None";

--- a/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRendererTest.java
+++ b/plugins/autodoc/autodoc-converters/src/test/java/org/eclipse/edc/plugins/autodoc/markdown/MarkdownManifestRendererTest.java
@@ -58,18 +58,40 @@ class MarkdownManifestRendererTest {
         assertThat(result).isNotNull().isEqualTo(testOutputStream);
     }
 
-    @Test
-    void convert_emptyObject() {
-        var list = List.of(EdcModule.Builder.newInstance().modulePath("foo").version("0.1.0-bar").build());
+    @Nested
+    class Heading {
 
-        var result = writer.convert(list);
+        @Test
+        void shouldRenderHeading() {
+            var list = List.of(EdcModule.Builder.newInstance().modulePath("foo:bar").version("0.1.0-baz").build());
 
-        assertThat(result).isNotNull().isEqualTo(testOutputStream).extracting(Object::toString).satisfies(markdown -> {
-            assertThat(markdown).contains("Module `foo:0.1.0-bar`");
-            assertThat(markdown).contains("### Extension points");
-            assertThat(markdown).contains("### Extensions");
-            assertThat(markdown).doesNotContain("Configuration:");
-        });
+            var result = writer.convert(list);
+
+            assertThat(result).isNotNull().isEqualTo(testOutputStream).extracting(Object::toString).satisfies(markdown -> {
+                assertThat(markdown).contains("Module `bar`");
+                assertThat(markdown).contains("_artifact: _foo:bar:0.1.0-baz");
+                assertThat(markdown).contains("### Extension points");
+                assertThat(markdown).contains("### Extensions");
+                assertThat(markdown).doesNotContain("Configuration:");
+            });
+        }
+
+        @Test
+        void shouldRenderHeading_whenModuleNameIsSet() {
+            var list = List.of(EdcModule.Builder.newInstance().name("module name").modulePath("foo:bar").version("0.1.0-baz").build());
+
+            var result = writer.convert(list);
+
+            assertThat(result).isNotNull().isEqualTo(testOutputStream).extracting(Object::toString).satisfies(markdown -> {
+                assertThat(markdown).contains("Module `bar`");
+                assertThat(markdown).contains("_name: _module name");
+                assertThat(markdown).contains("_artifact: _foo:bar:0.1.0-baz");
+                assertThat(markdown).contains("### Extension points");
+                assertThat(markdown).contains("### Extensions");
+                assertThat(markdown).doesNotContain("Configuration:");
+            });
+        }
+
     }
 
     @Nested
@@ -83,7 +105,9 @@ class MarkdownManifestRendererTest {
 
             var result = writer.convert(list);
 
-            assertThat(result).isNotNull().extracting(Object::toString).asString().contains("Configuration:").contains("`test.key`");
+            assertThat(result).isNotNull().extracting(Object::toString).asString()
+                    .contains("### Configuration:")
+                    .contains("`test.key`");
         }
 
         @Test
@@ -94,7 +118,9 @@ class MarkdownManifestRendererTest {
 
             var result = writer.convert(list);
 
-            assertThat(result).isNotNull().extracting(Object::toString).asString().contains("Configuration:").contains("~~test.key~~");
+            assertThat(result).isNotNull().extracting(Object::toString).asString()
+                    .contains("### Configuration:")
+                    .contains("~~test.key~~");
         }
     }
 


### PR DESCRIPTION
## What this PR changes/adds

remove heading
use only the module name on the title, all the further information are logged after then
set "configuration" as heading 3

## Why it does that

improve the visualization on the documentation website:
https://eclipse-edc.github.io/documentation/autodoc/connector/

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
