### PR TITLE
fix: in merge manifest set root build dir as default destination

### DIFF
--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MergeManifestsTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MergeManifestsTask.java
@@ -41,7 +41,8 @@ public abstract class MergeManifestsTask extends DefaultTask {
     public MergeManifestsTask() {
         appender = new JsonFileAppender(getProject().getLogger());
         projectBuildDirectory = getProject().getLayout().getBuildDirectory().getAsFile().get();
-        destinationFile = projectBuildDirectory.toPath().resolve(MERGED_MANIFEST_FILENAME).toFile();
+        destinationFile = getProject().getRootProject().getLayout().getBuildDirectory().get().getAsFile().toPath()
+                .resolve(MERGED_MANIFEST_FILENAME).toFile();
         inputDirectory = projectBuildDirectory.toPath().resolve("autodoc").toFile();
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Set root project build directory as the default destination for the merged autodoc manifest.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #277 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
