### PR TITLE
feat: autodoc parse @Configuration objects

### DIFF
--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessor.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessor.java
@@ -89,7 +89,7 @@ public class EdcModuleProcessor extends AbstractProcessor {
         //todo: replace this Noop converter with an actual JavadocConverter
         overviewIntrospector = new OverviewIntrospector(javadoc -> javadoc, processingEnv.getElementUtils());
 
-        extensionIntrospector = new ExtensionIntrospector(processingEnv.getElementUtils());
+        extensionIntrospector = new ExtensionIntrospector(processingEnv.getElementUtils(), processingEnv.getTypeUtils());
     }
 
     @Override


### PR DESCRIPTION
## What this PR changes/adds

this PR parses objects annotated with `@Configuration` and reads all the information from the `@Settings`-annotated elements within. In addition, the `ModuleIntrospector` now checks that `@Settings` may occur in extensions, or in objects annotated with `@Settings`, and `@Configuration`-annotated fields may only occur in extensions.

## Why it does that

Preparatory work for the config injection feature

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Contributes to https://github.com/eclipse-edc/Connector/issues/4610

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
