### PR TITLE
feat: optimize resolving manifests

### DIFF
--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/AbstractManifestResolveTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/AbstractManifestResolveTask.java
@@ -64,7 +64,7 @@ public abstract class AbstractManifestResolveTask extends DefaultTask {
         getProject().getConfigurations()
                 .stream().flatMap(config -> config.getDependencies().stream())
                 .distinct()
-                .filter(this::dependencyFilter)
+                .filter(this::includeDependency)
                 .filter(dep -> !getExclusions().contains(dep.getName()))
                 .map(this::createSource)
                 .filter(Optional::isPresent)
@@ -76,7 +76,15 @@ public abstract class AbstractManifestResolveTask extends DefaultTask {
         this.outputDirectoryOverride = new File(output);
     }
 
-    protected abstract boolean dependencyFilter(Dependency dependency);
+    /**
+     * Whether to consider a particular dependency for manifest resolution.
+     *
+     * @param dependency The dependency in question
+     * @return true if it should be considered, false otherwise.
+     */
+    protected boolean includeDependency(Dependency dependency) {
+        return true;
+    }
 
     /**
      * Returns an {@link InputStream} that points to the physical location of the autodoc manifest file.

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/AbstractManifestResolveTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/AbstractManifestResolveTask.java
@@ -19,7 +19,6 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/AbstractManifestResolveTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/AbstractManifestResolveTask.java
@@ -18,6 +18,8 @@ import org.eclipse.edc.plugins.autodoc.AutodocExtension;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
@@ -74,6 +76,11 @@ public abstract class AbstractManifestResolveTask extends DefaultTask {
     @Option(option = "output", description = "CLI option to override the output directory")
     public void setOutput(String output) {
         this.outputDirectoryOverride = new File(output);
+    }
+
+    @OutputDirectory
+    public File getOutputFile() {
+        return downloadDirectory.toFile();
     }
 
     /**

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DependencySource.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DependencySource.java
@@ -18,7 +18,6 @@ import org.gradle.api.artifacts.Dependency;
 
 import java.io.InputStream;
 import java.net.URI;
-import java.util.Objects;
 
 import static java.lang.String.format;
 
@@ -32,6 +31,8 @@ public abstract class DependencySource {
     private final String type;
 
     /**
+     * base constructor for a {@link DependencySource}
+     *
      * @param dependency the dependency in question
      * @param uri        the location where the physical file exists
      * @param classifier what type of dependency we have, e.g. sources, sources, manifest etc

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DependencySource.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DependencySource.java
@@ -74,11 +74,6 @@ public abstract class DependencySource {
         return type;
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(dependency, uri, classifier, type);
-    }
-
     /**
      * Opens an input stream to the file located at {@link DependencySource#uri()}. It is highly recommended to check {@link DependencySource#exists()}
      * beforehand.

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DependencySource.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DependencySource.java
@@ -16,28 +16,74 @@ package org.eclipse.edc.plugins.autodoc.tasks;
 
 import org.gradle.api.artifacts.Dependency;
 
+import java.io.InputStream;
 import java.net.URI;
+import java.util.Objects;
 
 import static java.lang.String.format;
 
 /**
  * Represents the combination of a dependency and a pointer (URL) to its physical location.
- *
- * @param dependency the dependency in question
- * @param uri        the location where the physical file exists
- * @param classifier what type of dependency we have, e.g. sources, sources, manifest etc
- * @param type       file extension
  */
-public record DependencySource(Dependency dependency, URI uri, String classifier, String type) {
-    @Override
-    public String toString() {
-        return "{" +
-                "dependency=" + dependency +
-                ", uri=" + uri +
-                '}';
+public abstract class DependencySource {
+    private final Dependency dependency;
+    private final URI uri;
+    private final String classifier;
+    private final String type;
+
+    /**
+     * @param dependency the dependency in question
+     * @param uri        the location where the physical file exists
+     * @param classifier what type of dependency we have, e.g. sources, sources, manifest etc
+     * @param type       file extension
+     */
+    public DependencySource(Dependency dependency, URI uri, String classifier, String type) {
+        this.dependency = dependency;
+        this.uri = uri;
+        this.classifier = classifier;
+        this.type = type;
     }
 
+    /**
+     * constructs the filename NAME-VERSION-CLASSIFIER.TYPE
+     */
     String filename() {
         return format("%s-%s-%s.%s", dependency.getName(), dependency.getVersion(), classifier, type);
     }
+
+    /**
+     * Checks whether a dependency exists. In some implementations this may involve remote calls, so use this with prejudice!
+     *
+     * @return whether the dependency exists, i.e. the {@link DependencySource#uri()} points to a valid file
+     */
+    public abstract boolean exists();
+
+    public Dependency dependency() {
+        return dependency;
+    }
+
+    public URI uri() {
+        return uri;
+    }
+
+    public String classifier() {
+        return classifier;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dependency, uri, classifier, type);
+    }
+
+    /**
+     * Opens an input stream to the file located at {@link DependencySource#uri()}. It is highly recommended to check {@link DependencySource#exists()}
+     * beforehand.
+     *
+     * @return Either the input stream to the file, or {@code null} if failed.
+     */
+    public abstract InputStream inputStream();
 }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DependencySourceFactory.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DependencySourceFactory.java
@@ -1,0 +1,16 @@
+package org.eclipse.edc.plugins.autodoc.tasks;
+
+import org.gradle.api.artifacts.Dependency;
+
+import java.net.URI;
+
+class DependencySourceFactory {
+    public static DependencySource createDependencySource(URI uri, Dependency dependency, String classifier, String type) {
+        if (uri.getScheme().equals("file")) {
+            return new FileSource(dependency, uri, classifier, type);
+        } else if (uri.getScheme().startsWith("http")) {
+            return new HttpSource(dependency, uri, classifier, type);
+        }
+        else throw new RuntimeException("Unknown URI scheme " + uri);
+    }
+}

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DependencySourceFactory.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DependencySourceFactory.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.plugins.autodoc.tasks;
 
 import org.gradle.api.artifacts.Dependency;
@@ -10,7 +24,8 @@ class DependencySourceFactory {
             return new FileSource(dependency, uri, classifier, type);
         } else if (uri.getScheme().startsWith("http")) {
             return new HttpSource(dependency, uri, classifier, type);
+        } else {
+            throw new RuntimeException("Unknown URI scheme " + uri);
         }
-        else throw new RuntimeException("Unknown URI scheme " + uri);
     }
 }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DownloadManifestTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DownloadManifestTask.java
@@ -17,14 +17,10 @@ package org.eclipse.edc.plugins.autodoc.tasks;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency;
-import org.gradle.api.tasks.OutputFile;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DownloadManifestTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DownloadManifestTask.java
@@ -18,7 +18,9 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency;
+import org.gradle.api.tasks.OutputFile;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -48,7 +50,6 @@ public class DownloadManifestTask extends AbstractManifestResolveTask {
             getLogger().warn("Could not obtain {}", autodocManifest.dependency());
             return null;
         }
-
         return inputStream;
     }
 
@@ -122,6 +123,4 @@ public class DownloadManifestTask extends AbstractManifestResolveTask {
             throw new RuntimeException(e);
         }
     }
-
-
 }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DownloadManifestTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/DownloadManifestTask.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.plugins.autodoc.tasks;
 
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency;
 
@@ -22,8 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
@@ -37,31 +36,20 @@ public class DownloadManifestTask extends AbstractManifestResolveTask {
     public static final String NAME = "downloadManifests";
     private static final Duration MAX_MANIFEST_AGE = Duration.ofHours(24);
 
-    private final HttpClient httpClient;
-
-    public DownloadManifestTask() {
-        httpClient = HttpClient.newHttpClient();
-    }
-
     @Override
-    protected boolean dependencyFilter(Dependency dependency) {
-        return !(dependency instanceof DefaultProjectDependency);
+    protected boolean includeDependency(Dependency dependency) {
+        return !(dependency instanceof ProjectDependency);
     }
 
     @Override
     protected InputStream resolveManifest(DependencySource autodocManifest) {
-        var request = HttpRequest.newBuilder().uri(autodocManifest.uri()).GET().build();
-        HttpResponse<InputStream> response;
-        try {
-            response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
-        } catch (IOException | InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-        if (response.statusCode() != 200) {
-            getLogger().warn("Could not download {}, HTTP response: {}", autodocManifest.dependency(), response);
+        var inputStream = autodocManifest.inputStream();
+        if (inputStream == null) {
+            getLogger().warn("Could not obtain {}", autodocManifest.dependency());
             return null;
         }
-        return response.body();
+
+        return inputStream;
     }
 
     /**
@@ -79,7 +67,7 @@ public class DownloadManifestTask extends AbstractManifestResolveTask {
     @Override
     protected Optional<DependencySource> createSource(Dependency dependency) {
         if (isLocalFileValid(dependency)) {
-            getLogger().debug("Local file {} was deemed to be viable, will not download", new DependencySource(dependency, null, MANIFEST_CLASSIFIER, MANIFEST_TYPE).filename());
+            getLogger().debug("Local file {} was deemed to be viable, will not download", dependency);
             return Optional.empty();
         }
         var repos = getProject().getRepositories().stream().toList();
@@ -89,18 +77,14 @@ public class DownloadManifestTask extends AbstractManifestResolveTask {
                 .map(repo -> {
                     var repoUrl = createArtifactUrl(dependency, repo);
                     try {
-                        // we use a HEAD request, because we only want to see whether that module has a `-manifest.json`
-                        var uri = URI.create(repoUrl);
-                        var headRequest = HttpRequest.newBuilder()
-                                .uri(uri)
-                                .method("HEAD", HttpRequest.BodyPublishers.noBody())
-                                .build();
-                        var response = httpClient.send(headRequest, HttpResponse.BodyHandlers.discarding());
-                        if (response.statusCode() == 200) {
-                            return new DependencySource(dependency, uri, MANIFEST_CLASSIFIER, MANIFEST_TYPE);
+                        var ds = DependencySourceFactory.createDependencySource(URI.create(repoUrl), dependency, MANIFEST_CLASSIFIER, MANIFEST_TYPE);
+                        if (ds.exists()) {
+                            getLogger().debug("Manifest found for '{}' at {}", dependency.getName(), ds.uri());
+                            return ds;
                         }
+                        getLogger().debug("Manifest not found for '{}' at {}", dependency.getName(), ds.uri());
                         return null;
-                    } catch (IOException | InterruptedException | IllegalArgumentException e) {
+                    } catch (IllegalArgumentException e) {
                         return null;
                     }
                 })
@@ -126,7 +110,8 @@ public class DownloadManifestTask extends AbstractManifestResolveTask {
      */
     private boolean isLocalFileValid(Dependency dep) {
         if (!downloadDirectory.toFile().exists()) return false;
-        var filePath = downloadDirectory.resolve(new DependencySource(dep, null, MANIFEST_CLASSIFIER, MANIFEST_TYPE).filename());
+        var filename = format("%s-%s-%s.%s", dep.getName(), dep.getVersion(), MANIFEST_CLASSIFIER, MANIFEST_TYPE);
+        var filePath = downloadDirectory.resolve(filename);
         var file = filePath.toFile();
         if (!file.exists() || !file.canRead()) return false;
 

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/FileSource.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/FileSource.java
@@ -7,6 +7,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * A dependency that is represented in the local file system, e.g. the local Maven cache
@@ -24,7 +26,7 @@ public class FileSource extends DependencySource {
 
     @Override
     public boolean exists() {
-        return new File(uri()).exists();
+        return Files.exists(Path.of(uri()));
     }
 
     @Override

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/FileSource.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/FileSource.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.plugins.autodoc.tasks;
 
 import org.gradle.api.artifacts.Dependency;
@@ -15,6 +29,8 @@ import java.nio.file.Path;
  */
 public class FileSource extends DependencySource {
     /**
+     * Instantiates a new file source
+     *
      * @param dependency the dependency in question
      * @param uri        the location where the physical file exists
      * @param classifier what type of dependency we have, e.g. sources, sources, manifest etc

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/FileSource.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/FileSource.java
@@ -1,0 +1,38 @@
+package org.eclipse.edc.plugins.autodoc.tasks;
+
+import org.gradle.api.artifacts.Dependency;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.net.URI;
+
+/**
+ * A dependency that is represented in the local file system, e.g. the local Maven cache
+ */
+public class FileSource extends DependencySource {
+    /**
+     * @param dependency the dependency in question
+     * @param uri        the location where the physical file exists
+     * @param classifier what type of dependency we have, e.g. sources, sources, manifest etc
+     * @param type       file extension
+     */
+    public FileSource(Dependency dependency, URI uri, String classifier, String type) {
+        super(dependency, uri, classifier, type);
+    }
+
+    @Override
+    public boolean exists() {
+        return new File(uri()).exists();
+    }
+
+    @Override
+    public InputStream inputStream() {
+        try {
+            return new FileInputStream(new File(uri()));
+        } catch (FileNotFoundException e) {
+            return null;
+        }
+    }
+}

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/HttpSource.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/HttpSource.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.plugins.autodoc.tasks;
 
 import org.gradle.api.artifacts.Dependency;
@@ -17,6 +31,8 @@ public class HttpSource extends DependencySource {
 
 
     /**
+     * Instantiates a new HTTP source for dependencies
+     *
      * @param dependency the dependency in question
      * @param uri        the location where the physical file exists
      * @param classifier what type of dependency we have, e.g. sources, sources, manifest etc
@@ -49,6 +65,7 @@ public class HttpSource extends DependencySource {
 
     /**
      * Opens an input stream to the remote file. If the remote file does not exist, {@code null} is returned.
+     *
      * @throws RuntimeException if the HTTP request raises an {@link IOException} or an {@link InterruptedException}
      */
     @Override
@@ -60,7 +77,7 @@ public class HttpSource extends DependencySource {
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }
-        if(response.statusCode() == 200) {
+        if (response.statusCode() == 200) {
             return response.body();
         }
         return null;

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/HttpSource.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/HttpSource.java
@@ -1,0 +1,68 @@
+package org.eclipse.edc.plugins.autodoc.tasks;
+
+import org.gradle.api.artifacts.Dependency;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * A dependency that is located in a remote repository, such as Maven Central
+ */
+public class HttpSource extends DependencySource {
+    private final HttpClient httpClient;
+
+
+    /**
+     * @param dependency the dependency in question
+     * @param uri        the location where the physical file exists
+     * @param classifier what type of dependency we have, e.g. sources, sources, manifest etc
+     * @param type       file extension
+     */
+    public HttpSource(Dependency dependency, URI uri, String classifier, String type) {
+        super(dependency, uri, classifier, type);
+        httpClient = HttpClient.newHttpClient();
+
+    }
+
+    /**
+     * A HEAD request is performed to check if the file is actually present at the remote location.
+     */
+    @Override
+    public boolean exists() {
+        var headRequest = HttpRequest.newBuilder()
+                .uri(uri())
+                .method("HEAD", HttpRequest.BodyPublishers.noBody())
+                .build();
+        try {
+            var response = httpClient.send(headRequest, HttpResponse.BodyHandlers.discarding());
+            return response.statusCode() == 200;
+        } catch (IOException e) {
+            return false;
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Opens an input stream to the remote file. If the remote file does not exist, {@code null} is returned.
+     * @throws RuntimeException if the HTTP request raises an {@link IOException} or an {@link InterruptedException}
+     */
+    @Override
+    public InputStream inputStream() {
+        var request = HttpRequest.newBuilder().uri(uri()).GET().build();
+        HttpResponse<InputStream> response;
+        try {
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        if(response.statusCode() == 200) {
+            return response.body();
+        }
+        return null;
+    }
+}

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/ResolveManifestTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/ResolveManifestTask.java
@@ -55,7 +55,7 @@ public class ResolveManifestTask extends AbstractManifestResolveTask {
         if (dependency instanceof DefaultProjectDependency localDependency) {
             var manifestFile = localDependency.getDependencyProject().getLayout().getBuildDirectory().file("edc.json");
             if (manifestFile.isPresent()) {
-                return Optional.of(DependencySourceFactory.createDependencySource( manifestFile.get().getAsFile().toURI(), dependency, MANIFEST_CLASSIFIER, MANIFEST_TYPE));
+                return Optional.of(DependencySourceFactory.createDependencySource(manifestFile.get().getAsFile().toURI(), dependency, MANIFEST_CLASSIFIER, MANIFEST_TYPE));
             } else {
                 getLogger().debug("No manifest file found for dependency {}", dependency);
             }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/ResolveManifestTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/ResolveManifestTask.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.plugins.autodoc.tasks;
 
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency;
 
 import java.io.File;
@@ -29,8 +30,8 @@ public class ResolveManifestTask extends AbstractManifestResolveTask {
     public static final String DESCRIPTION = "This task is intended for BOM modules and resolves the autodoc manifests of all modules that the project depends on. By default, all manifests are stored in {project}/build/autodoc.";
 
     @Override
-    protected boolean dependencyFilter(Dependency dependency) {
-        return dependency instanceof DefaultProjectDependency;
+    protected boolean includeDependency(Dependency dependency) {
+        return dependency instanceof ProjectDependency;
     }
 
     @Override
@@ -51,10 +52,10 @@ public class ResolveManifestTask extends AbstractManifestResolveTask {
 
     @Override
     protected Optional<DependencySource> createSource(Dependency dependency) {
-        if (dependency instanceof DefaultProjectDependency localDepdendency) {
-            var manifestFile = localDepdendency.getDependencyProject().getLayout().getBuildDirectory().file("edc.json");
+        if (dependency instanceof DefaultProjectDependency localDependency) {
+            var manifestFile = localDependency.getDependencyProject().getLayout().getBuildDirectory().file("edc.json");
             if (manifestFile.isPresent()) {
-                return Optional.of(new DependencySource(localDepdendency, manifestFile.get().getAsFile().toURI(), MANIFEST_CLASSIFIER, MANIFEST_TYPE));
+                return Optional.of(DependencySourceFactory.createDependencySource( manifestFile.get().getAsFile().toURI(), dependency, MANIFEST_CLASSIFIER, MANIFEST_TYPE));
             } else {
                 getLogger().debug("No manifest file found for dependency {}", dependency);
             }


### PR DESCRIPTION
## What this PR changes/adds

improves the manifest resolution tasks and declares task outputs for the `downloadManifests` task.
In addition, this PR adds facilities to resolve dependency files from both HTTP and the file system. This could come in handy when dealing with local builds.

## Why it does that

avoid unnecessary task invocations

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
