### PR TITLE
build: add missing dependency to openapi-merger

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ jetbrainsAnnotation = "26.0.1"
 jakarta-ws-rs = "4.0.0"
 jupiter = "5.11.3"
 mockito = "5.14.2"
+openapi-merger = "1.0.5"
 swagger = "2.2.22"
 swagger-parser = "2.1.24"
 
@@ -28,11 +29,10 @@ markdown-gen = { module = "net.steppschuh.markdowngenerator:markdowngenerator", 
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 plugin-checksum = { module = "gradle.plugin.org.gradle.crypto:checksum", version = "1.4.0" }
 plugin-nexus-publish = { module = "io.github.gradle-nexus:publish-plugin", version = "2.0.0" }
-plugin-openapi-merger = { module = "com.rameshkp:openapi-merger-gradle-plugin", version = "1.0.5" }
+plugin-openapi-merger = { module = "com.rameshkp:openapi-merger-gradle-plugin", version.ref = "openapi-merger" }
+plugin-openapi-merger-app = { module = "com.rameshkp:openapi-merger-app", version.ref = "openapi-merger" }
 plugin-swagger = { module = "io.swagger.core.v3:swagger-gradle-plugin", version.ref = "swagger" }
 swagger-parser = { module = "io.swagger.parser.v3:swagger-parser", version.ref = "swagger-parser" }
-
-[bundles]
 
 [plugins]
 publish = { id = "com.gradle.plugin-publish", version = "1.3.0" }

--- a/plugins/openapi-merger/build.gradle.kts
+++ b/plugins/openapi-merger/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 val group: String by project
 
 dependencies {
+    implementation(libs.plugin.openapi.merger.app)
     implementation(libs.plugin.openapi.merger) {
         constraints {
             implementation(libs.swagger.parser) {


### PR DESCRIPTION
## What this PR changes/adds

Fix the first build issue described in #298 by adding a missing dependency to the `openapi-merger` plugin module.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

the other issue described in one issue comment it's still there, but it could be tackled separately.

## Linked Issue(s)

Part of #298  

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
