### PR TITLE
feat(autodoc): use description annotation field and value as fallback

### DIFF
--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ExtensionIntrospector.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ExtensionIntrospector.java
@@ -151,9 +151,14 @@ public class ExtensionIntrospector {
                 .orElseGet(() -> attributeValue(String.class, "key", settingMirror, elementUtils))
                 .toString();
 
+        var description = Stream.of(
+                attributeValue(String.class, "description", settingMirror, elementUtils),
+                attributeValue(String.class, "value", settingMirror, elementUtils)
+        ).filter(Objects::nonNull).filter(it -> !it.isEmpty()).findFirst().orElse(null);
+
         return ConfigurationSetting.Builder.newInstance()
                 .key(keyValue)
-                .description(attributeValue(String.class, "value", settingMirror, elementUtils))
+                .description(description)
                 .type(attributeValue(String.class, "type", settingMirror, elementUtils))
                 .required(attributeValue(Boolean.class, "required", settingMirror, elementUtils))
                 .maximum(attributeValue(Long.class, "max", settingMirror, elementUtils))


### PR DESCRIPTION
## What this PR changes/adds

Makes the autodoc processor to read `description` attribute of `@Setting`, leaving `value` (deprecated) as fallback

## Why it does that

autodoc

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #307 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
