### PR TITLE
build: fix build

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,18 +22,10 @@ jobs:
     uses: eclipse-edc/.github/.github/workflows/codeql-analysis.yml@main
     secrets: inherit
 
-  Checkstyle:
+  Build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
-      - name: Run Checkstyle
-        run: ./gradlew checkstyleMain checkstyleTest
-
-  Unit-Tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: eclipse-edc/.github/.github/actions/setup-build@main
-      - name: Run unit tests
-        run: ./gradlew test
+      - name: Build
+        run: ./gradlew build

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/AbstractManifestResolveTask.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/AbstractManifestResolveTask.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.plugins.autodoc.tasks;
 import org.eclipse.edc.plugins.autodoc.AutodocExtension;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
@@ -82,6 +82,11 @@ public abstract class AbstractManifestResolveTask extends DefaultTask {
         return downloadDirectory.toFile();
     }
 
+    @Input
+    public Set<String> getExclusions() {
+        return Set.of();
+    }
+
     /**
      * Whether to consider a particular dependency for manifest resolution.
      *
@@ -95,15 +100,8 @@ public abstract class AbstractManifestResolveTask extends DefaultTask {
     /**
      * Returns an {@link InputStream} that points to the physical location of the autodoc manifest file.
      */
-    @Internal //otherwise it would get interpreted as task input :/
     protected abstract InputStream resolveManifest(DependencySource autodocManifest);
 
-    @Internal //otherwise it would get interpreted as task input :/
-    protected Set<String> getExclusions() {
-        return Set.of();
-    }
-
-    @Internal //otherwise it would get interpreted as task input :/
     protected abstract Optional<DependencySource> createSource(Dependency dependency);
 
     private void transferDependencyFile(DependencySource dependencySource, Path downloadDirectory) {


### PR DESCRIPTION
## What this PR changes/adds

Removes `@Internal` annotations where not needed (it only has meaning on getters)  and use `@Input` where the attribute is supposed to be considered as an input ("exclusions" should be configurable).

Unified checkstyle and test jobs into `build`, as it runs both of them, plus the time it takes is practically the same

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #298 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
