### PR TITLE
build: remove unneeded `runtime-metamodel` dependencies

### DIFF
--- a/plugins/autodoc/autodoc-plugin/build.gradle.kts
+++ b/plugins/autodoc/autodoc-plugin/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
 }
 
 dependencies {
-    implementation(libs.edc.runtime.metamodel)
     implementation(libs.jetbrains.annotations)
     implementation(libs.jackson.core)
     implementation(libs.jackson.databind)

--- a/plugins/edc-build/build.gradle.kts
+++ b/plugins/edc-build/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
     implementation(project(":plugins:module-names"))
     implementation(project(":plugins:openapi-merger"))
 
-    implementation(libs.edc.runtime.metamodel)
     implementation(libs.plugin.nexus.publish)
     implementation(libs.plugin.checksum)
     implementation(libs.plugin.swagger)

--- a/plugins/module-names/build.gradle.kts
+++ b/plugins/module-names/build.gradle.kts
@@ -20,7 +20,3 @@ gradlePlugin {
         }
     }
 }
-
-dependencies {
-    implementation(libs.edc.runtime.metamodel)
-}

--- a/plugins/test-summary/build.gradle.kts
+++ b/plugins/test-summary/build.gradle.kts
@@ -20,7 +20,3 @@ gradlePlugin {
         }
     }
 }
-
-dependencies {
-    implementation(libs.edc.runtime.metamodel)
-}


### PR DESCRIPTION
## What this PR changes/adds

Cleans up unneeded dependencies to runtime-metamodel

## Why it does that

Demonstrate that we can get rid of the chicken-egg problem with the `edc-build` plugin, because the runtime metamodel is only needed for the `autodoc-plugin`, that could be extracted from this repo, while the edc-build plugin release could be detached from edc release and also published on gradle portal ([as suggested in this discussion](https://github.com/eclipse-edc/GradlePlugins/discussions/295))

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
