### PR TITLE
build: switch repository url to the newest one

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,10 +10,13 @@ group = "org.eclipse.edc"
 repositories {
     mavenCentral()
     maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
     }
     gradlePluginPortal()
     mavenLocal()
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots/") // deprecated
+    }
 }
 
 dependencies {

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/NexusPublishingConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/NexusPublishingConvention.java
@@ -15,21 +15,31 @@
 package org.eclipse.edc.plugins.edcbuild.conventions;
 
 import io.github.gradlenexus.publishplugin.NexusPublishExtension;
+import io.github.gradlenexus.publishplugin.NexusRepository;
 import org.gradle.api.Project;
 
-import static org.eclipse.edc.plugins.edcbuild.conventions.Repositories.sonatypeRepo;
+import java.net.URI;
 
 class NexusPublishingConvention implements EdcConvention {
+
+    private static final String OSSRH_USER = "OSSRH_USER";
+    private static final String OSSRH_PASSWORD = "OSSRH_PASSWORD";
 
     @Override
     public void apply(Project target) {
         if (target == target.getRootProject()) {
 
-
             target.getExtensions().configure(NexusPublishExtension.class, nexusPublishExtension -> {
-                nexusPublishExtension.repositories(sonatypeRepo());
+                nexusPublishExtension.repositories(c -> c.sonatype(this::configure));
             });
         }
+    }
+
+    private void configure(NexusRepository r) {
+        r.getNexusUrl().set(URI.create(Repositories.NEXUS_REPO_URL));
+        r.getSnapshotRepositoryUrl().set(URI.create(Repositories.SNAPSHOT_REPO_URL));
+        r.getUsername().set(System.getenv(OSSRH_USER));
+        r.getPassword().set(System.getenv(OSSRH_PASSWORD));
     }
 
 

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/Repositories.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/Repositories.java
@@ -14,37 +14,12 @@
 
 package org.eclipse.edc.plugins.edcbuild.conventions;
 
-import io.github.gradlenexus.publishplugin.NexusRepository;
-import io.github.gradlenexus.publishplugin.NexusRepositoryContainer;
-import org.gradle.api.Action;
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-
-import java.net.URI;
-
 public class Repositories {
 
-    public static final String REPO_NAME_SONATYPE = "OSSRH";
-    public static final String SNAPSHOT_REPO_URL = "https://oss.sonatype.org/content/repositories/snapshots/";
-    public static final String NEXUS_REPO_URL = "https://oss.sonatype.org/service/local/";
-    private static final String OSSRH_PASSWORD = "OSSRH_PASSWORD";
-    private static final String OSSRH_USER = "OSSRH_USER";
+    public static final String NEXUS_REPO_URL = "https://ossrh-staging-api.central.sonatype.com/service/local/";
+    public static final String SNAPSHOT_REPO_URL = "https://central.sonatype.com/repository/maven-snapshots/";
 
-    public static Action<MavenArtifactRepository> mavenRepo(String repoUrl) {
-        return repo -> {
-            repo.setUrl(repoUrl);
-        };
-    }
+    @Deprecated(since = "0.14.0")
+    public static final String DEPRECATED_SNAPSHOT_REPO_URL = "https://oss.sonatype.org/content/repositories/snapshots/";
 
-    public static Action<? super NexusRepositoryContainer> sonatypeRepo() {
-        return c -> c.sonatype(nexusRepo(NEXUS_REPO_URL, SNAPSHOT_REPO_URL));
-    }
-
-    private static Action<? super NexusRepository> nexusRepo(String nexusRepoUrl, String snapshotRepoUrl) {
-        return r -> {
-            r.getNexusUrl().set(URI.create(nexusRepoUrl));
-            r.getSnapshotRepositoryUrl().set(URI.create(snapshotRepoUrl));
-            r.getUsername().set(System.getenv(OSSRH_USER));
-            r.getPassword().set(System.getenv(OSSRH_PASSWORD));
-        };
-    }
 }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/RepositoriesConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/RepositoriesConvention.java
@@ -26,8 +26,9 @@ class RepositoriesConvention implements EdcConvention {
     @Override
     public void apply(Project target) {
         var handler = target.getRepositories();
+        handler.maven(r -> r.setUrl(URI.create(Repositories.SNAPSHOT_REPO_URL)));
         handler.mavenLocal();
-        handler.maven(r -> r.setUrl(URI.create("https://oss.sonatype.org/content/repositories/snapshots/")));
         handler.mavenCentral();
+        handler.maven(r -> r.setUrl(URI.create(Repositories.DEPRECATED_SNAPSHOT_REPO_URL)));
     }
 }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/RootBuildScriptConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/RootBuildScriptConvention.java
@@ -16,8 +16,7 @@ package org.eclipse.edc.plugins.edcbuild.conventions;
 
 import org.gradle.api.Project;
 
-import static org.eclipse.edc.plugins.edcbuild.conventions.Repositories.SNAPSHOT_REPO_URL;
-import static org.eclipse.edc.plugins.edcbuild.conventions.Repositories.mavenRepo;
+import static org.eclipse.edc.plugins.edcbuild.conventions.Repositories.DEPRECATED_SNAPSHOT_REPO_URL;
 
 /**
  * Configures the root buildscript, i.e. adds repos
@@ -26,11 +25,10 @@ class RootBuildScriptConvention implements EdcConvention {
     @Override
     public void apply(Project target) {
         if (target == target.getRootProject()) {
-            // configure buildscript repos
             target.getBuildscript().getRepositories().mavenLocal();
             target.getBuildscript().getRepositories().mavenCentral();
             target.getBuildscript().getRepositories().gradlePluginPortal();
-            target.getBuildscript().getRepositories().maven(mavenRepo(SNAPSHOT_REPO_URL));
+            target.getBuildscript().getRepositories().maven(repo -> repo.setUrl(DEPRECATED_SNAPSHOT_REPO_URL));
         }
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Switches:
- snapshot repo url to `https://central.sonatype.com/repository/maven-snapshots/`
- nexus url to `https://ossrh-staging-api.central.sonatype.com/service/local/`

Keeps old snapshot repository to soften the transition

## Why it does that

[_Briefly state why the change was necessary._](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#plugins-tested-for-compatibility)

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #341

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
