### PR TITLE
fix: autodoc publication manifest registration

### DIFF
--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
@@ -65,9 +65,9 @@ public class AutodocPlugin implements Plugin<Project> {
         });
 
         project.afterEvaluate(p -> {
-            var manifestFile = p.getLayout().getBuildDirectory().file("edc.json");
+            var manifestFile = p.getLayout().getBuildDirectory().file("edc.json").get().getAsFile();
 
-            if (!manifestFile.isPresent()) {
+            if (!manifestFile.exists()) {
                 return;
             }
 


### PR DESCRIPTION
## What this PR changes/adds

Fixes the check to decide to add the manifest artifact to the publication.

## Why it does that

To avoid issues like the ones that are arising during the nightlies: https://github.com/eclipse-edc/Connector/actions/runs/16562891660/job/46837009034

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
