### PR TITLE
build(deps): avoid chicken-egg problem on edc test dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ format.version = "1.1"
 assertj = "3.27.3"
 checkstyle = "10.26.1"
 edc = "0.14.0-SNAPSHOT"
+# the edc-boot-spi dependency is used only for tests, this fixed version prevents the "chicken-egg" problem
+edc-test = "0.13.2"
 jackson = "2.19.2"
 jetbrainsAnnotation = "26.0.2"
 jakarta-ws-rs = "4.0.0"
@@ -18,7 +20,7 @@ swagger-parser = "2.1.31"
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" }
 edc-runtime-metamodel = { module = "org.eclipse.edc:runtime-metamodel", version.ref = "edc" }
-edc-core-spi = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
+edc-boot-spi = { module = "org.eclipse.edc:boot-spi", version.ref = "edc-test" }
 j2html = { module = "com.j2html:j2html", version = "1.6.0" }
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }

--- a/plugins/autodoc/autodoc-processor/build.gradle.kts
+++ b/plugins/autodoc/autodoc-processor/build.gradle.kts
@@ -18,5 +18,5 @@ plugins {
 dependencies {
     api(libs.edc.runtime.metamodel)
 
-    testImplementation(libs.edc.core.spi)
+    testImplementation(libs.edc.boot.spi)
 }


### PR DESCRIPTION
## What this PR changes/adds

Fix the `boot-spi` dependency version to an actual release version

## Why it does that

Avoid chicken-egg problem and it will make the repository always "buildable" also during nightly builds

## Further notes

- at this point that we made edc-build independent from EDC, to avoid this problem we should move some interfaces from `boot-spi` to `runtime-metamodel`, but given that's just a test dependency I guess we can live with that like it is


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
