### PR TITLE
feat: add task to wait until all the artifacts in the current release are available on MC

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/EdcBuildPlugin.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/EdcBuildPlugin.java
@@ -36,6 +36,7 @@ import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.rootBuild
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.signing;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.swagger;
 import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.tests;
+import static org.eclipse.edc.plugins.edcbuild.conventions.Conventions.waitForPublishedArtifacts;
 
 /**
  * Adds (opinionated) conventions (=configuration) for various plugins.
@@ -77,7 +78,8 @@ public class EdcBuildPlugin implements Plugin<Project> {
                     tests(),
                     jar(),
                     swagger(),
-                    printClasspath()
+                    printClasspath(),
+                    waitForPublishedArtifacts()
             ).forEach(c -> c.apply(project));
         });
 

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/Conventions.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/Conventions.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.edc.plugins.edcbuild.conventions;
 
+import org.eclipse.edc.plugins.edcbuild.tasks.WaitForPublishedArtifacts;
+
 /**
  * Contains statically accessible {@link EdcConvention} objects that can be applied to a project.
  */
@@ -81,5 +83,9 @@ public class Conventions {
 
     public static EdcConvention printClasspath() {
         return new PrintClasspathConvention();
+    }
+
+    public static EdcConvention waitForPublishedArtifacts() {
+        return new WaitForPublishedArtifactsConvention();
     }
 }

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/WaitForPublishedArtifactsConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/WaitForPublishedArtifactsConvention.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.edcbuild.conventions;
+
+import org.eclipse.edc.plugins.edcbuild.tasks.WaitForPublishedArtifacts;
+import org.gradle.api.Project;
+
+public class WaitForPublishedArtifactsConvention implements EdcConvention {
+    @Override
+    public void apply(Project target) {
+        target.getTasks().register("waitForPublishedArtifacts", WaitForPublishedArtifacts.class);
+    }
+}

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/tasks/WaitForPublishedArtifacts.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/tasks/WaitForPublishedArtifacts.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.edcbuild.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.tasks.TaskAction;
+
+import java.net.URL;
+import java.time.LocalDateTime;
+
+import static java.lang.Thread.sleep;
+import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.requireExtension;
+
+/**
+ * Task for root project that looks up for published artifacts, waiting if they are not available.
+ * After a certain timeout the task fails
+ */
+public class WaitForPublishedArtifacts extends DefaultTask {
+
+    private static final int TASK_TIMEOUT_MINUTES = 60;
+    private static final int RETRY_WAIT_SECONDS = 30;
+
+    @TaskAction
+    public void waitForPublishedArtifacts() {
+        requireExtension(getProject(), PublishingExtension.class)
+                .getPublications().stream()
+                .map(MavenPublication.class::cast)
+                .forEach(this::lookUpForPublication);
+    }
+
+    private void lookUpForPublication(MavenPublication publication) {
+        if (publication.getVersion().endsWith("-SNAPSHOT")) {
+            throw new IllegalStateException("This task can only be executed on proper releases, not on snapshots");
+        }
+        var artifact = publication.getName() + " " + publication.getGroupId() + ":" + publication.getArtifactId() + ":" + publication.getVersion();
+        var repo = RepositoryHandler.MAVEN_CENTRAL_URL;
+
+        var timeout = LocalDateTime.now().plusMinutes(TASK_TIMEOUT_MINUTES);
+        var found = false;
+        while (!found && timeout.isAfter(LocalDateTime.now())) {
+            try {
+                var url = repo + publication.getGroupId().replace('.', '/') +
+                        "/" + publication.getArtifactId() + "/" + publication.getVersion() +
+                        "/" + publication.getArtifactId() + "-" + publication.getVersion() +
+                        ".pom";
+                new URL(url).openStream().close();
+                found = true;
+            } catch (Throwable e) {
+                getLogger().warn("Artifact {} is NOT available on maven central, will try again in {} seconds", artifact, RETRY_WAIT_SECONDS);
+                try {
+                    sleep(RETRY_WAIT_SECONDS * 1000);
+                } catch (InterruptedException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        }
+
+        if (!found) {
+            throw new IllegalStateException("Artifact %s has not been found maven central after %s minutes".formatted(artifact, TASK_TIMEOUT_MINUTES));
+        }
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Adds a `waitForPublishedArtifacts`, that, only for non-snapshot publications (proper releases) will wait until the artifacts are actually available on maven central.
The timeout has been set as 1 hour, with the new publishing mechanism that has been put in place the publish time is around 20 minutes or so.

## Why it does that

During our release process to ensure that everything runs flawlessly we need to wait until all the artifacts of an upstream project are available before triggering the next one, e.g. after Connector release we have to wait the dependencies availability for the IdentityHub release process.
By adding this task we can make all the process automatic without much human intervention

## Further notes

- the way we are registering tasks into this `EdcConvention` mechanism looks a little convoluted, it could be a good target for a refactoring that will easily point to the registered tasks in a breeze, without having to dive into different classes and methods


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
