### PR TITLE
fix: exclude modules that should not be published from the waitForPublishedArtifacts

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenPublicationConvention.java
@@ -23,8 +23,6 @@ import static org.eclipse.edc.plugins.edcbuild.conventions.ConventionFunctions.r
 
 public class MavenPublicationConvention implements EdcConvention {
 
-    private static final boolean DEFAULT_SHOULD_PUBLISH = true;
-
     @Override
     public void apply(Project target) {
         // do not publish the root project or modules without a build.gradle.kts
@@ -33,9 +31,8 @@ public class MavenPublicationConvention implements EdcConvention {
         }
 
         var buildExtension = requireExtension(target, BuildExtension.class);
-        var shouldPublish = buildExtension.getPublish().getOrElse(DEFAULT_SHOULD_PUBLISH);
 
-        if (shouldPublish) {
+        if (buildExtension.shouldPublish()) {
             target.getPlugins().apply(MavenPublishPlugin.class);
 
             target.getExtensions().configure(MavenPublishBaseExtension.class, extension -> {

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/BuildExtension.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/extensions/BuildExtension.java
@@ -24,6 +24,9 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion;
  * Root configuration resource for the EDC Build plugin
  */
 public abstract class BuildExtension {
+
+    private static final boolean DEFAULT_SHOULD_PUBLISH = true;
+
     private final MavenPomExtension pom;
     private final SwaggerGeneratorExtension swagger;
 
@@ -48,6 +51,15 @@ public abstract class BuildExtension {
 
     public SwaggerGeneratorExtension getSwagger() {
         return swagger;
+    }
+
+    /**
+     * Tell if the module needs to be published
+     *
+     * @return true if the module needs to be published, false otherwise
+     */
+    public boolean shouldPublish() {
+        return getPublish().getOrElse(DEFAULT_SHOULD_PUBLISH);
     }
 
     public abstract Property<Boolean> getPublish();

--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/tasks/WaitForPublishedArtifacts.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/tasks/WaitForPublishedArtifacts.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.plugins.edcbuild.tasks;
 
+import org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.publish.PublishingExtension;
@@ -37,6 +38,10 @@ public class WaitForPublishedArtifacts extends DefaultTask {
 
     @TaskAction
     public void waitForPublishedArtifacts() {
+        if (!requireExtension(getProject(), BuildExtension.class).shouldPublish()) {
+            return;
+        }
+
         requireExtension(getProject(), PublishingExtension.class)
                 .getPublications().stream()
                 .map(MavenPublication.class::cast)


### PR DESCRIPTION
## What this PR changes/adds

Add a check on the `waitForPublishedArtifacts` to properly exclude modules that should not be published (despite having proper publications, like `edc-build`)

## Why it does that

Avoid issues like this: https://github.com/eclipse-edc/GradlePlugins/actions/runs/17060584871/job/48366616897

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
