### PR TITLE
fix: skip example generation on merge openapi spec

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/plugins/MergeOpenApiSpecTask.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/plugins/MergeOpenApiSpecTask.java
@@ -54,6 +54,7 @@ public class MergeOpenApiSpecTask extends GenerateTask {
         getInputSpecRootDirectorySkipMerge().set(false);
         getSkipValidateSpec().set(true);
         getGeneratorName().set("openapi-yaml");
+        getSkipOperationExample().set(false);
         getOutputDir().set(buildOpenapiFolder.dir("generated").getAsFile().getAbsolutePath());
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Avoid example generation in case of missing one.

## Why it does that

The examples generated are not the best and they get clients confused, better to stick to the mode it was with the deprecated `mergeApiSpec` task: examples should be provided manually or not.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
