### PR TITLE
chore: add maven local as first repo

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/RepositoriesConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/RepositoriesConvention.java
@@ -26,8 +26,8 @@ class RepositoriesConvention implements EdcConvention {
     @Override
     public void apply(Project target) {
         var handler = target.getRepositories();
-        handler.maven(r -> r.setUrl(URI.create(Repositories.SNAPSHOT_REPO_URL)));
         handler.mavenLocal();
+        handler.maven(r -> r.setUrl(URI.create(Repositories.SNAPSHOT_REPO_URL)));
         handler.mavenCentral();
         handler.maven(r -> r.setUrl(URI.create(Repositories.DEPRECATED_SNAPSHOT_REPO_URL)));
     }


### PR DESCRIPTION
## What this PR changes/adds

add maven local as first repo

## Why it does that

When testing local changes, otherwise maven local won't be used

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
