### PR TITLE
fix: compile errors after @Setting cleanup

### DIFF
--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ExtensionIntrospector.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ExtensionIntrospector.java
@@ -152,14 +152,12 @@ public class ExtensionIntrospector {
                 .toString();
 
         var description = Stream.of(
-                attributeValue(String.class, "description", settingMirror, elementUtils),
-                attributeValue(String.class, "value", settingMirror, elementUtils)
+                attributeValue(String.class, "description", settingMirror, elementUtils)
         ).filter(Objects::nonNull).filter(it -> !it.isEmpty()).findFirst().orElse(null);
 
         return ConfigurationSetting.Builder.newInstance()
                 .key(keyValue)
                 .description(description)
-                .type(attributeValue(String.class, "type", settingMirror, elementUtils))
                 .required(attributeValue(Boolean.class, "required", settingMirror, elementUtils))
                 .maximum(attributeValue(Long.class, "max", settingMirror, elementUtils))
                 .minimum(attributeValue(Long.class, "min", settingMirror, elementUtils))

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/test/ConfigurationExtensionWithSetting.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/test/ConfigurationExtensionWithSetting.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.spi.system.configuration.Config;
 
 public class ConfigurationExtensionWithSetting implements ConfigurationExtension {
 
-    @Setting("Valid because this is an extension of ServiceExtension")
+    @Setting(description = "Valid because this is an extension of ServiceExtension")
     private static final String VALID_SETTING = "any";
 
     @Override

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/test/NotExtensionWithSetting.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/test/NotExtensionWithSetting.java
@@ -17,6 +17,6 @@ package org.eclipse.edc.plugins.autodoc.core.processor.test;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 
 public class NotExtensionWithSetting {
-    @Setting("the setting must stay in a ServiceExtension class")
+    @Setting(description = "the setting must stay in a ServiceExtension class")
     private static final String UNEXPECTED_SETTING = "any";
 }

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testextensions/SampleExtensionWithoutAnnotation.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testextensions/SampleExtensionWithoutAnnotation.java
@@ -25,11 +25,11 @@ import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_SETT
 
 @Provides(SomeOtherService.class)
 public class SampleExtensionWithoutAnnotation implements ServiceExtension {
-    @Setting(value = Constants.TEST_SETTING_NAME, required = true, defaultValue = TEST_SETTING_DEFAULT_VALUE)
+    @Setting(description = Constants.TEST_SETTING_NAME, required = true, defaultValue = TEST_SETTING_DEFAULT_VALUE)
     public static final String TEST_SETTING = Constants.TEST_SETTING_KEY;
 
     @Deprecated(since = "forever")
-    @Setting(value = "deprecated")
+    @Setting(description = "deprecated")
     public static final String DEPRECATED_TEST_SETTING = Constants.TEST_DEPRECATED_SETTING_KEY;
 
     @Inject


### PR DESCRIPTION
## What this PR changes/adds

fixes compile and test errors after deprecation cleanup of the `@Setting` annotation

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
