### PR TITLE
fix: removes unneeded dependency to 'openapi' task

### DIFF
--- a/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenArtifactConvention.java
+++ b/plugins/edc-build/src/main/java/org/eclipse/edc/plugins/edcbuild/conventions/MavenArtifactConvention.java
@@ -58,7 +58,6 @@ class MavenArtifactConvention implements EdcConvention {
                                 addArtifactIfExist(target, openapiFile, mavenPub, artifact -> {
                                     artifact.setClassifier(getFilenameWithoutExtension(openapiFile));
                                     artifact.setType("yaml");
-                                    artifact.builtBy("openapi");
                                 });
                             }
                         }


### PR DESCRIPTION
## What this PR changes/adds

Removes unnecessary dependency to the `openapi` task, that is causing failures in version 1.5.1 during artifact publication ([see](https://github.com/eclipse-edc/Connector/actions/runs/24642860822/job/72049856213)).

The `openapi*` task is already set as a dependency of the `jar` task so it will always run before the publishing convention.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
