### PR TITLE
fix: @Configuration autodoc, with context

### DIFF
--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ExtensionIntrospector.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ExtensionIntrospector.java
@@ -21,20 +21,23 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Spi;
 import org.eclipse.edc.runtime.metamodel.domain.ConfigurationSetting;
 import org.eclipse.edc.runtime.metamodel.domain.Service;
 import org.eclipse.edc.runtime.metamodel.domain.ServiceReference;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -103,15 +106,18 @@ public class ExtensionIntrospector {
     }
 
     /**
-     * Resolves configuration points declared with {@link Setting}.
+     * Resolves configuration points declared with {@link Setting} and {@link Configuration}
      */
     public List<ConfigurationSetting> resolveConfigurationSettings(Element element) {
         var settingsInConfigObjects = getEnclosedElementsAnnotatedWith(element, Configuration.class)
-                .flatMap(e -> getEnclosedElementsAnnotatedWith(typeUtils.asElement(e.asType()), Setting.class));
+                .map(this::extractConfigurationContext)
+                .flatMap(configurationContext -> getEnclosedSettings(configurationContext.type())
+                        .map(configurationElement -> new VariableElementContext(configurationContext.context(), configurationElement)));
 
-        return Stream.concat(settingsInConfigObjects, getEnclosedElementsAnnotatedWith(element, Setting.class))
-                .filter(VariableElement.class::isInstance)
-                .map(VariableElement.class::cast)
+        var settingElements = getEnclosedSettings(element)
+                .map(settingElement -> new VariableElementContext(null, settingElement));
+
+        return Stream.concat(settingsInConfigObjects, settingElements)
                 .map(this::createConfigurationSetting)
                 .collect(toList());
     }
@@ -127,6 +133,11 @@ public class ExtensionIntrospector {
         return element.asType().toString();
     }
 
+    private @NotNull Stream<VariableElement> getEnclosedSettings(Element type) {
+        return getEnclosedElementsAnnotatedWith(type, Setting.class)
+                .filter(VariableElement.class::isInstance)
+                .map(VariableElement.class::cast);
+    }
 
     /**
      * Returns a stream consisting of the {@code extensionElement}'s enclosed {@link Element}s, that are annotated with the given annotation class.
@@ -139,21 +150,18 @@ public class ExtensionIntrospector {
     /**
      * Maps a {@link ConfigurationSetting} from an {@link Setting} annotation.
      */
-    private ConfigurationSetting createConfigurationSetting(VariableElement settingElement) {
+    private ConfigurationSetting createConfigurationSetting(VariableElementContext variableElementContext) {
+        var settingElement = variableElementContext.element();
         var settingMirror = mirrorFor(Setting.class, settingElement);
-        var prefix = attributeValue(String.class, CONTEXT_ATTRIBUTE, settingMirror, elementUtils);
-        if (prefix.isEmpty()) {
-            prefix = resolveConfigurationPrefix(settingElement);
-        }
+        var prefix = getPrefix(settingMirror, variableElementContext.context());
 
         // either take the config key value directly from the annotated variable or from the "key" attribute
         var keyValue = prefix + ofNullable(settingElement.getConstantValue())
                 .orElseGet(() -> attributeValue(String.class, "key", settingMirror, elementUtils))
                 .toString();
 
-        var description = Stream.of(
-                attributeValue(String.class, "description", settingMirror, elementUtils)
-        ).filter(Objects::nonNull).filter(it -> !it.isEmpty()).findFirst().orElse(null);
+        var description = Stream.of(attributeValue(String.class, "description", settingMirror, elementUtils))
+                .filter(Objects::nonNull).filter(it -> !it.isEmpty()).findFirst().orElse(null);
 
         return ConfigurationSetting.Builder.newInstance()
                 .key(keyValue)
@@ -166,16 +174,58 @@ public class ExtensionIntrospector {
                 .build();
     }
 
-    /**
-     * Resolves a configuration prefix specified by {@link SettingContext} for a given EDC setting element or an empty string if there is none.
-     */
-    @NotNull
-    private String resolveConfigurationPrefix(VariableElement edcSettingElement) {
-        var enclosingElement = edcSettingElement.getEnclosingElement();
-        if (enclosingElement == null) {
-            return "";
+    private @NotNull String getPrefix(AnnotationMirror settingMirror, String configurationContext) {
+        var prefix = attributeValue(String.class, CONTEXT_ATTRIBUTE, settingMirror, elementUtils);
+        if (!prefix.isBlank()) {
+            return appendDotIfNeeded(prefix);
         }
-        var contextMirror = mirrorFor(SettingContext.class, enclosingElement);
-        return contextMirror != null ? attributeValue(String.class, "value", contextMirror, elementUtils) : "";
+
+        if (configurationContext != null) {
+            return appendDotIfNeeded(configurationContext);
+        }
+
+        return "";
     }
+
+    private @NotNull String appendDotIfNeeded(String string) {
+        return string + (string.endsWith(".") ? "" : ".");
+    }
+
+
+    private ConfigurationContext extractConfigurationContext(Element e) {
+        var settingContext = getSettingContext(e);
+
+        var currentType = e.asType();
+        var mapTypeElement = elementUtils.getTypeElement(Map.class.getName());
+        var mapType = typeUtils.getDeclaredType(mapTypeElement,
+                typeUtils.getWildcardType(null, null),
+                typeUtils.getWildcardType(null, null)
+        );
+
+        if (typeUtils.isAssignable(currentType, mapType)) {
+            var mapGenericType = ((DeclaredType) currentType).getTypeArguments().get(1);
+            return new ConfigurationContext(settingContext + ".<alias>", typeUtils.asElement(mapGenericType));
+        }
+
+        return new ConfigurationContext(settingContext, typeUtils.asElement(currentType));
+    }
+
+    private @Nullable String getSettingContext(Element e) {
+        var context = e.getAnnotation(Configuration.class).context();
+        if (!context.isBlank()) {
+            return context;
+        }
+
+        return ofNullable(mirrorFor(org.eclipse.edc.runtime.metamodel.annotation.SettingContext.class, e))
+                .map(annotationMirror -> attributeValue(String.class, "value", annotationMirror, elementUtils))
+                .orElse(null);
+    }
+
+    private record VariableElementContext(String context, VariableElement element) {
+
+    }
+
+    private record ConfigurationContext(String context, Element type) {}
+
+
 }

--- a/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ModuleIntrospector.java
+++ b/plugins/autodoc/autodoc-processor/src/main/java/org/eclipse/edc/plugins/autodoc/core/processor/introspection/ModuleIntrospector.java
@@ -96,7 +96,6 @@ public class ModuleIntrospector {
      */
     public Set<Element> getExtensionElements(RoundEnvironment environment) {
 
-
         var settingsSymbols = environment.getElementsAnnotatedWith(Setting.class).stream()
                 .peek(setting -> {
                     var serviceExtensionType = typeUtils.erasure(elementUtils.getTypeElement(SYSTEM_EXTENSION_NAME).asType());
@@ -110,9 +109,8 @@ public class ModuleIntrospector {
                     }
                 });
 
-        // check that fields annotated with @Configuration occur only inside extension classes
-        environment.getElementsAnnotatedWith(Configuration.class)
-                .forEach(setting -> {
+        var configurationSymbols = environment.getElementsAnnotatedWith(Configuration.class).stream()
+                .peek(setting -> {
                     var serviceExtensionType = typeUtils.erasure(elementUtils.getTypeElement(SYSTEM_EXTENSION_NAME).asType());
                     var enclosingElement = setting.getEnclosingElement().asType();
 
@@ -126,7 +124,7 @@ public class ModuleIntrospector {
         var injectSymbols = environment.getElementsAnnotatedWith(Inject.class);
         var providerSymbols = environment.getElementsAnnotatedWith(Provider.class);
 
-        var classes = Stream.of(settingsSymbols, injectSymbols.stream(), providerSymbols.stream())
+        var classes = Stream.of(settingsSymbols, configurationSymbols, injectSymbols.stream(), providerSymbols.stream())
                 .reduce(Stream::concat)
                 .orElse(Stream.empty())
                 .map(Element::getEnclosingElement)

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/Constants.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/Constants.java
@@ -22,7 +22,6 @@ public interface Constants {
     String TEST_SPI_MODULE = "Test SPI Module";
 
     String TEST_FIELD_PREFIX_SETTING_KEY = "edc.prefix.field.";
-    String TEST_CLASS_PREFIX_SETTING_KEY = "edc.prefix.class.";
     String TEST_SETTING_ID_KEY = "id";
 
 }

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessorTest.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/EdcModuleProcessorTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.plugins.autodoc.core.processor;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.plugins.autodoc.core.processor.testconfig.ServiceExtensionWithConfig;
 import org.eclipse.edc.plugins.autodoc.core.processor.testextensions.NotAnExtension;
 import org.eclipse.edc.plugins.autodoc.core.processor.testextensions.OptionalService;
 import org.eclipse.edc.plugins.autodoc.core.processor.testextensions.RequiredService;
@@ -31,6 +32,7 @@ import org.eclipse.edc.runtime.metamodel.domain.EdcServiceExtension;
 import org.eclipse.edc.runtime.metamodel.domain.Service;
 import org.eclipse.edc.runtime.metamodel.domain.ServiceReference;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -48,6 +50,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.tools.Diagnostic;
@@ -59,7 +62,6 @@ import javax.tools.ToolProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_CLASS_PREFIX_SETTING_KEY;
 import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_FIELD_PREFIX_SETTING_KEY;
 import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_SETTING_DEFAULT_VALUE;
 import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_SETTING_ID_KEY;
@@ -256,9 +258,37 @@ public class EdcModuleProcessorTest {
 
             assertThat(ext1.getConfiguration())
                     .extracting(ConfigurationSetting::getKey)
-                    .contains(TEST_CLASS_PREFIX_SETTING_KEY + TEST_SETTING_ID_KEY, TEST_FIELD_PREFIX_SETTING_KEY + TEST_SETTING_ID_KEY);
+                    .contains(TEST_SETTING_ID_KEY, TEST_FIELD_PREFIX_SETTING_KEY + TEST_SETTING_ID_KEY);
         }
 
+    }
+
+    @Nested
+    class Configuration {
+        @Test
+        void shouldAddConfigurationContextAsPrefix() {
+            createTask("testconfig").call();
+
+            var modules = readManifest();
+
+            assertThat(modules).hasSize(1).first()
+                    .extracting(EdcModule::getExtensions)
+                    .extracting(serviceExtensions -> getExtension(serviceExtensions, ServiceExtensionWithConfig.class))
+                    .isNotNull()
+                    .satisfies(extension -> {
+                        assertThat(extension.getConfiguration()).hasSize(3)
+                                .extracting(ConfigurationSetting::getKey)
+                                .containsExactlyInAnyOrder(
+                                        "edc.configuration.context.setting",
+                                        "edc.configuration.map.<alias>.setting",
+                                        "edc.configuration.context.deprecated.setting");
+                    });
+
+        }
+
+        private @Nullable EdcServiceExtension getExtension(Set<EdcServiceExtension> serviceExtension, Class<?> clazz) {
+            return serviceExtension.stream().filter(it -> it.getName().equals(clazz.getSimpleName())).findFirst().orElse(null);
+        }
     }
 
     @Test
@@ -319,8 +349,9 @@ public class EdcModuleProcessorTest {
 
     private List<EdcModule> readManifest() {
         try (var files = Files.list(tempDir)) {
-            var url = files.filter(p -> p.endsWith("edc.json")).findFirst().orElseThrow(AssertionError::new).toUri().toURL();
-            return OBJECT_MAPPER.readValue(url, new TypeReference<>() { });
+            var stream = files.filter(p -> p.endsWith("edc.json")).findFirst().orElseThrow(AssertionError::new)
+                    .toUri().toURL().openStream();
+            return OBJECT_MAPPER.readValue(stream, new TypeReference<>() { });
         } catch (IOException e) {
             throw new AssertionError(e);
         }

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testconfig/ServiceExtensionWithConfig.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testconfig/ServiceExtensionWithConfig.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.plugins.autodoc.core.processor.testconfig;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.system.ServiceExtension;
+
+import java.util.Map;
+
+public class ServiceExtensionWithConfig implements ServiceExtension {
+
+    @Configuration(context = "edc.configuration.context")
+    private ConfigurationObject configuration;
+
+    @Configuration(context = "edc.configuration.map")
+    private Map<String, ConfigurationObject> configurationObjectMap;
+
+    @SettingContext("edc.configuration.context.deprecated")
+    @Configuration
+    private ConfigurationObject configurationWithDeprecatedSettingContext;
+
+    @Settings
+    public record ConfigurationObject(
+            @Setting(key = "setting") String setting
+    ) {
+
+    }
+}

--- a/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testextensions/SettingContextExtension.java
+++ b/plugins/autodoc/autodoc-processor/src/test/java/org/eclipse/edc/plugins/autodoc/core/processor/testextensions/SettingContextExtension.java
@@ -16,14 +16,11 @@ package org.eclipse.edc.plugins.autodoc.core.processor.testextensions;
 
 import org.eclipse.edc.plugins.autodoc.core.processor.Constants;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.spi.system.ServiceExtension;
 
-import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_CLASS_PREFIX_SETTING_KEY;
 import static org.eclipse.edc.plugins.autodoc.core.processor.Constants.TEST_FIELD_PREFIX_SETTING_KEY;
 
 
-@SettingContext(TEST_CLASS_PREFIX_SETTING_KEY)
 public class SettingContextExtension implements ServiceExtension {
 
     @Setting(context = TEST_FIELD_PREFIX_SETTING_KEY)


### PR DESCRIPTION
## What this PR changes/adds

Fix autodoc for `@Configuration` objects, including `context` (also through the use of deprecated class `@SettingContext`).

## Why it does that

autodoc

## Further notes
- removed the case in which `@SettingContext` is used on a type as not really relevant

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #453 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
